### PR TITLE
Add end-to-end test for spark-shell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,11 @@ project/project/*
 .#*
 .project
 .settings
+.classpath
 key.asc
+*~
+.spark-dist
+spark
+spark-*.tgz
+metastore_db
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ cache:
   directories:
     - $HOME/.sbt
     - $HOME/.ivy2
+    - .spark-dist
 
 services:
   - docker
@@ -41,6 +42,19 @@ matrix:
             tags: true
 
     - jdk: openjdk8
+
+    - jdk: openjdk8
+
+      env:
+        - END_TO_END=true
+
+      before_script:
+        - make docker-bblfsh
+
+      script:
+        - make build
+        - ./_tools/getApacheSpark.sh "2.2.0" "2.7"
+        - ./spark/bin/spark-shell --jars ./target/engine-uber.jar -i src/test/resources/SparkShellScript.scala
 
     - language: python
       python: 2.7
@@ -80,7 +94,7 @@ matrix:
             tags: true
 
 before_script:
-  - docker run --privileged -d -p 9432:9432 --name bblfsh bblfsh/server
+  - make docker-bblfsh
 
 script:
   - make travis-test

--- a/_tools/getApacheSpark.sh
+++ b/_tools/getApacheSpark.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# A helper script to get Apache Spark spark-shell on CI mahine
+# Use TravisCI cache to minimize load on ASF mirrors
+
+
+
+if [[ "$#" -ne 2 ]]; then
+    echo "usage) $0 [spark version] [hadoop version]"
+    echo "   eg) $0 2.2.0 2.7"
+    exit 1
+fi
+
+
+SPARK_VERSION=$1
+HADOOP_VERSION=$2
+
+SPARK_CACHE=".spark-dist"
+SPARK_ARCHIVE="spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}"
+
+
+log() {
+  echo "[$(date +'%Y-%m-%dT%H:%M:%S%z')]: $@" >&2
+}
+
+download_with_retry() {
+    local url="$1"
+    wget -O "${SPARK_ARCHIVE}.tgz" --retry-connrefused --waitretry=1 --read-timeout=20 --timeout=15 -t 3 "${url}"
+    if [[ "$?" -ne 0 ]]; then
+        log "3 download attempts for ${url} failed"
+    fi
+}
+
+mkdir -p "${SPARK_CACHE}"
+cd "${SPARK_CACHE}"
+if [[ ! -f "${SPARK_ARCHIVE}.tgz" ]]; then
+    pwd
+    ls -la .
+    log "${SPARK_CACHE} does not have ${SPARK_ARCHIVE}.tgz downloading ..."
+
+    # download spark from archive if not cached
+    log "$Apache Spark {SPARK_VERSION} being downloaded from archives"
+    start_time=`date +%s`
+    download_with_retry "https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=spark/spark-${SPARK_VERSION}/${SPARK_ARCHIVE}.tgz"
+    end_time=`date +%s`
+    download_time="$((end_time-start_time))"
+    log "Took ${download_time} sec"
+else
+    log "Using Apache Spark distr from ${SPARK_CACHE}"
+fi
+ 
+# extract archive in un-cached root, clean-up on failure
+cp "${SPARK_ARCHIVE}.tgz" ..
+cd ..
+if ! tar zxf "${SPARK_ARCHIVE}.tgz" ; then
+    log "Unable to extract ${SPARK_ARCHIVE}.tgz" >&2
+    rm -rf "${SPARK_ARCHIVE}"
+    rm -f "${SPARK_ARCHIVE}.tgz"
+fi
+
+mv "${SPARK_ARCHIVE}" spark

--- a/python/Makefile
+++ b/python/Makefile
@@ -1,2 +1,4 @@
+include ../Makefile
+
 test:
 	PYSPARK_SUBMIT_ARGS="$(pwd)/jars/

--- a/src/test/resources/SparkShellScript.scala
+++ b/src/test/resources/SparkShellScript.scala
@@ -1,0 +1,24 @@
+import tech.sourced.api._
+
+
+//End-to-end test of packages spark-api.jar intended to be used with ./spark-shell -i SparkShellScript.scala
+//it's not part of src/test/scala to avoid compilation during build
+spark.version
+
+try {
+  val engine = engine(spark, "./src/test/resources/siva-files/")
+  val files = engine.getRepositories.getReferences.filter('name === "refs/heads/HEAD").getFiles
+  files.show(2)
+
+  val langs = files.classifyLanguages
+  langs.show(2)
+
+  val ex = langs.extractUASTs
+  ex.show(2)
+} catch {
+  case e: _ =>
+    e.printStackTrace()
+    System.exit(2)
+}
+
+System.exit(0)


### PR DESCRIPTION
This test runs actual `spark-shell --jars engine-uber.jar`

It's purpose is to catch any dependency miss-match at runtime that might happen due to transitive dependencies collision at build time.