### PR TITLE
Download siva-java dependency from maven central

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,8 +21,6 @@ lazy val root = (project in file(".")).
     libraryDependencies += commonsIO % Compile,
     libraryDependencies += enry % Compile,
 
-    resolvers += "jitpack" at "https://jitpack.io",
-
     test in assembly := {},
     assemblyJarName in assembly := s"${name.value}-uber.jar"
   )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   lazy val newerHadoopClient = "org.apache.hadoop" % "hadoop-client" % "2.7.2"
   lazy val fixNettyForGrpc = "io.netty" % "netty-all" % "4.1.11.Final"
   lazy val jgit = "org.eclipse.jgit" % "org.eclipse.jgit" % "4.9.0.201710071750-r"
-  lazy val siva = "com.github.src-d" % "siva-java" % "master-SNAPSHOT"
+  lazy val siva = "tech.sourced" % "siva-java" % "0.1.1"
   lazy val bblfsh = "org.bblfsh" % "bblfsh-client" % "1.3.3"
   lazy val enry = "tech.sourced" % "enry-java" % "1.5.1"
   lazy val commonsIO = "commons-io" % "commons-io" % "2.5"


### PR DESCRIPTION
Since `siva-java` is now available on `maven central`, the dependency can be obtained from there instead from `jitpack`.