### PR TITLE
Fixed skipCleanup option

### DIFF
--- a/src/main/scala/tech/sourced/engine/DefaultSource.scala
+++ b/src/main/scala/tech/sourced/engine/DefaultSource.scala
@@ -66,8 +66,8 @@ case class GitRelation(sqlContext: SQLContext,
 
   private val localPath: String = UtilsWrapper.getLocalDir(sqlContext.sparkContext.getConf)
   private val path: String = sqlContext.getConf(repositoriesPathKey)
-  private val skipCleanup: Boolean = sqlContext.sparkContext.getConf
-    .getBoolean(skipCleanupKey, defaultValue = false)
+  private val skipCleanup: Boolean = sqlContext.sparkSession.conf.
+    get(skipCleanupKey, default = "false").toBoolean
 
   override def unhandledFilters(filters: Array[Filter]): Array[Filter] = {
     super.unhandledFilters(filters)

--- a/src/main/scala/tech/sourced/engine/Engine.scala
+++ b/src/main/scala/tech/sourced/engine/Engine.scala
@@ -157,7 +157,7 @@ class Engine(session: SparkSession) {
     * @return instance of the engine itself
     */
   def skipCleanup(skip: Boolean): Engine = {
-    session.sparkContext.getConf.set(skipCleanupKey, skip.toString)
+    session.conf.set(skipCleanupKey, skip)
     this
   }
 


### PR DESCRIPTION
***This PR is related to https://github.com/src-d/engine/issues/132***

- I tested the changes and I could see how the siva-files aren't remove when the skipCleanup option is set to true while they were always removed before regardless the option were set or not.

***What was happening***
The `skinCleanup` K-V configuration was being set in the [SparkConf](https://spark.apache.org/docs/latest/api/scala/index.html#org.apache.spark.SparkConf) object which is the configuration for the [SparkContext](https://spark.apache.org/docs/latest/api/scala/index.html#org.apache.spark.SparkContext). It is in charge to manage the cluster's configuration stuffs. The `SparkConf` is given and cloned to the `SparkContext` when it is instantiated, so after that the `SparkConf` can't be used to add and remove additional configuration dynamically because they wouldn't actually tracked.

On the other hand, [SQLContext]() and [SparkSession]() have both configuration maps that we can use for get and set our own configuration things dynamically.

`SQLContext` is the old entry point to work with the SQL api things, meanwhile `SparkSession` is the new recommended way to do that. `SparkSession` encapsulate the `SparkContext` and the `SQLContext` for backward compatibility.

Although `sqlContext.getAllConfs`(the configuration Map(String, String)) and the `spark.conf.getAll` (the `SparkSession` configuration Map(String, String)) are different objects:

```scala
scala> spark.sqlContext.getAllConfs eq spark.conf.getAll
res3: Boolean = false
```

Both maps track the same K-V pairs:

```scala
scala> spark.sqlContext.getAllConfs == spark.conf.getAll
res4: Boolean = true
```

So when an option is set in one of them, automatically is added to the other too:

```scala
scala> spark.conf.set("spark.tech.sourced.engine.test.key", "test-value")

scala> spark.conf.get("spark.tech.sourced.engine.test.key")
res6: String = test-value

scala> spark.sqlContext.getConf("spark.tech.sourced.engine.test.key")
res8: String = test-value

scala> spark.sqlContext.getAllConfs eq spark.conf.getAll
res9: Boolean = false

scala> spark.sqlContext.getAllConfs == spark.conf.getAll
res10: Boolean = true
```

This is the way we should handle our own configuration things, not using the `SparkConf` object.

As it showed before `SQLContext` and `SparkSession` can be used for this purpose, but in my opinion, it's better use it through the `SparkSession` configuration since is the object "officially" recommended to be the entry point to the SQL API.
