### PR TITLE
Normalize spark configuration and SparkSession/SQLContext/SparkContext usage

### DIFF
--- a/src/main/scala/tech/sourced/engine/Engine.scala
+++ b/src/main/scala/tech/sourced/engine/Engine.scala
@@ -137,7 +137,7 @@ class Engine(session: SparkSession) {
         s"so siva files can't be read from there")
     }
 
-    session.sqlContext.setConf(repositoriesPathKey, path)
+    session.conf.set(repositoriesPathKey, path)
     this
   }
 


### PR DESCRIPTION
The main reason for this PR comes from #144.

Changes:
- Replaced `SQLContext`by `SparkSession` objects where possible.
- Use of `SparkSession.conf`instead of `SQLContext.getConf` to handle the K-V configuration store.
- I guessed that `Provider` classes are providing `RDD` to be able to use just with `spark.core` without `spark.sql`, so they still are using `SparkContext` 