### PR TITLE
Removed val localPathKey

### DIFF
--- a/src/main/scala/tech/sourced/engine/package.scala
+++ b/src/main/scala/tech/sourced/engine/package.scala
@@ -44,10 +44,6 @@ package object engine {
   // The keys repositoriesPathKey, bblfshHostKey, bblfshPortKey and skipCleanupKey must
   // start by "spark." to be able to be loaded from the "spark-defaults.conf" file.
 
-
-  /** Local spark directory. */
-  private[engine] val localPathKey = "spark.local.dir"
-
   /**
     * Implicit class that adds some functions to the [[org.apache.spark.sql.SparkSession]].
     *


### PR DESCRIPTION
This PR removes `val localPathKey`

### Explanation ###

```scala
  /** Local spark directory. */
  private[engine] val localPathKey = "spark.local.dir"
```

This is private to the engine package, but it is not used anywhere, so it could be removed.

On the other hand, we have the wrapper:

```scala
  object UtilsWrapper {
    def getLocalDir(conf: SparkConf): String = Utils.getLocalDir(conf)
  }

```

Which returns the current value for the local dir configuration.

About local dir configuration it can be set in different ways and this function explicits the preferenced order spark uses (from the `Utils.getLocalDir`'s scaladoc):

```scala
  /**
   * Get the path of a temporary directory.  Spark's local directories can be configured through
   * multiple settings, which are used with the following precedence:
   *
   *   - If called from inside of a YARN container, this will return a directory chosen by YARN.
   *   - If the SPARK_LOCAL_DIRS environment variable is set, this will return a directory from it.
   *   - Otherwise, if the spark.local.dir is set, this will return a directory from it.
   *   - Otherwise, this will return java.io.tmpdir.
   *
   * Some of these configuration options might be lists of multiple paths, but this method will
   * always return a single directory.
   */
```

Also, as an additional information, `spark.local.dir` is set to `/tmp` by default.