### PR TITLE
Modified python/Makefile to simplify testing task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,26 +47,22 @@ matrix:
 
       install:
         - make build
-        - mkdir -p python/jars
-        - cp target/engine-uber.jar python/jars
         - cd python
         - pip install -r requirements.txt
 
       script:
-        - python -m unittest discover -v
+        - make test
 
     - language: python
       python: 3.6
 
       install:
         - make build
-        - mkdir -p python/jars
-        - cp target/engine-uber.jar python/jars
         - cd python
         - pip install -r requirements.txt
 
       script:
-        - python -m unittest discover -v
+        - make test
 
       before_deploy:
         - echo "$TRAVIS_TAG" | cut -c 2- > version.txt

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ To run tests for python wrapper:
 
 ```bash
 $ cd python
-$ python -m unittest discover -v
+$ make test
 ```
 
 ### Windows support

--- a/python/Makefile
+++ b/python/Makefile
@@ -1,2 +1,18 @@
-test:
-	PYSPARK_SUBMIT_ARGS="$(pwd)/jars/
+ENGINE_UBER_JAR = engine-uber.jar
+ENGINE_UBER_JAR_LOCATION = ../target/$(ENGINE_UBER_JAR)
+JARS_DIR = jars
+
+
+$(JARS_DIR):
+	mkdir -p $(JARS_DIR)
+
+.PHONY: test clean
+test: clean $(JARS_DIR)
+	cp $(ENGINE_UBER_JAR_LOCATION) $(JARS_DIR) && \
+	python -m unittest discover -v
+
+clean:
+	if [ -d $(JARS_DIR) ] ; \
+	then \
+		rm -r $(JARS_DIR) ; \
+	fi


### PR DESCRIPTION
This PR simplifies the python testing task, at least in local.

Changes:
- `python/Makefile` does the copy of the fatjar before run python test
- python test are running now just with `cd python; make test`
- changed the `.travis.yml` to use the `make test` rule
- changed the `README` to reflect the changes