### PR TITLE
Improve Jobs speed while reading siva files.

### DIFF
--- a/src/main/scala/tech/sourced/engine/provider/RepositoryProvider.scala
+++ b/src/main/scala/tech/sourced/engine/provider/RepositoryProvider.scala
@@ -2,7 +2,6 @@ package tech.sourced.engine.provider
 
 import java.io.File
 import java.nio.file.Paths
-import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
 
 import org.apache.commons.io.FileUtils
@@ -16,6 +15,7 @@ import tech.sourced.siva.SivaReader
 
 import scala.collection.JavaConverters._
 import scala.collection.concurrent
+import scala.collection.concurrent.TrieMap
 
 /**
   * Generates repositories from siva files at the given local path and keeps a reference count
@@ -30,13 +30,13 @@ class RepositoryProvider(val localPath: String, val skipCleanup: Boolean = false
     * Map to keep track of all the repository instances open.
     */
   private val repositories: concurrent.Map[String, Repository] =
-    new ConcurrentHashMap[String, Repository]().asScala
+    new TrieMap[String, Repository]()
 
   /**
     * Map to keep track of the reference count of all repositories.
     */
   private val repoRefCounts: concurrent.Map[String, AtomicInteger] =
-    new ConcurrentHashMap[String, AtomicInteger]().asScala
+    new TrieMap[String, AtomicInteger]()
 
   /**
     * Thread-safe method to get a repository given an HDFS configuration and its path.

--- a/src/main/scala/tech/sourced/engine/provider/RepositoryProvider.scala
+++ b/src/main/scala/tech/sourced/engine/provider/RepositoryProvider.scala
@@ -28,12 +28,16 @@ class RepositoryProvider(val localPath: String, val skipCleanup: Boolean = false
 
   /**
     * Map to keep track of all the repository instances open.
+    * The getOrElseUpdate method implementation of this Map instance
+    * must be thread-safe.
     */
   private val repositories: concurrent.Map[String, Repository] =
     new TrieMap[String, Repository]()
 
   /**
     * Map to keep track of the reference count of all repositories.
+    * The getOrElseUpdate method implementation of this Map instance
+    * must be thread-safe.
     */
   private val repoRefCounts: concurrent.Map[String, AtomicInteger] =
     new TrieMap[String, AtomicInteger]()


### PR DESCRIPTION
Remove unnecesary syncronized signature in a method and refactor the content a bit to make the Repository creation faster.

Executing:

spark.time(engine.getRepositories.getReferences.count())

on a 1000 siva files sample, local machine with master=local[8]

Before: 3.88253333 min
After: 2.23136667 min