### PR TITLE
Refactor use of SparkContext in buildScan

### DIFF
--- a/src/main/scala/tech/sourced/engine/DefaultSource.scala
+++ b/src/main/scala/tech/sourced/engine/DefaultSource.scala
@@ -78,13 +78,12 @@ case class GitRelation(session: SparkSession,
   }
 
   override def buildScan(requiredColumns: Seq[Attribute], filters: Seq[Expression]): RDD[Row] = {
-    val sc = session.sparkContext
-    val sivaRDD = SivaRDDProvider(sc).get(path)
+    val sivaRDD = SivaRDDProvider(session.sparkContext).get(path)
 
-    val requiredCols = sc.broadcast(requiredColumns.map(_.name).toArray)
-    val reposLocalPath = sc.broadcast(localPath)
-    val sources = sc.broadcast(GitRelation.getSources(tableSource, schema))
-    val filtersBySource = sc.broadcast(GitRelation.getFiltersBySource(filters))
+    val requiredCols = session.sparkContext.broadcast(requiredColumns.map(_.name).toArray)
+    val reposLocalPath = session.sparkContext.broadcast(localPath)
+    val sources = session.sparkContext.broadcast(GitRelation.getSources(tableSource, schema))
+    val filtersBySource = session.sparkContext.broadcast(GitRelation.getFiltersBySource(filters))
 
     sivaRDD.flatMap(pds => {
       val provider = RepositoryProvider(reposLocalPath.value, skipCleanup)


### PR DESCRIPTION
It's just a nitpick, but I saw that in UDF's code we are using the same pattern and I think this helps to clarify the relations among `SparkSession/SparkContext/SQLContext..` and so on.

Also, I know the `val sc` is being used in a short code scope, but I don't like so much this kind of abbreviation for names even in this cases.

This is just a personal point of view, but I think it could be help unexperienced people like me to understand better these spark's things.

What do you think?