### PR TITLE
Use an object pool to mange Repositories instances

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,7 @@ libraryDependencies += jgit % Compile
 libraryDependencies += siva % Compile
 libraryDependencies += bblfsh % Compile
 libraryDependencies += commonsIO % Compile
+libraryDependencies += commonsPool % Compile
 libraryDependencies += enry % Compile
 
 test in assembly := {}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,4 +11,6 @@ object Dependencies {
   lazy val bblfsh = "org.bblfsh" % "bblfsh-client" % "1.3.3"
   lazy val enry = "tech.sourced" % "enry-java" % "1.5.1"
   lazy val commonsIO = "commons-io" % "commons-io" % "2.5"
+  lazy val commonsPool = "org.apache.commons" % "commons-pool2" % "2.4.3"
+
 }

--- a/src/main/scala/tech/sourced/engine/DefaultSource.scala
+++ b/src/main/scala/tech/sourced/engine/DefaultSource.scala
@@ -128,7 +128,7 @@ case class GitRelation(session: SparkSession,
         case other => throw new SparkException(s"required cols for '$other' is not supported")
       })
 
-      new CleanupIterator(iter.getOrElse(Seq().toIterator), provider.close(pds.getPath()))
+      new CleanupIterator(iter.getOrElse(Seq().toIterator), provider.close(pds, repo))
     })
   }
 }


### PR DESCRIPTION
This change manage to process ~1200 siva files repositories in less time:

Executed code: 
```scala
spark.time(engine.getRepositories.getReferences.count())
```

Using one core:
- Before: ~5 min
- Now: ~4,5 min

Using 8 cores:
- Before: ~4 min
- Now: ~2 min