### PR TITLE
better error message when engine is missing from pyspark

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,30 @@ You should have a [bblfsh daemon](https://github.com/bblfsh/bblfshd) container r
 
 When the `engine-jupyter` container starts it will show you an URL that you can open in your browser.
 
+# Using engine directly from Python
+
+If you are using engine directly from Python and are unable to modify the `PYTHON_SUBMIT_ARGS` you can copy the engine jar to the pyspark jars to make it available there.
+
+```
+cp engine.jar "$(python -c 'import pyspark; print(pyspark.__path__[0])'/jars"
+```
+
+This way, you can use it in the following way:
+
+```python
+import sys
+
+pyspark_path = "/path/to/pyspark/python"
+sys.path.append(pyspark_path)
+
+from pyspark.sql import SparkSession
+from sourced.engine import Engine
+
+siva_folder = "/path/to/siva-files"
+spark = SparkSession.builder.appName("test").master("local[*]").getOrCreate()
+engine = Engine(spark, siva_folder)
+```
+
 # Development
 
 ## Build fatjar

--- a/python/sourced/engine/engine.py
+++ b/python/sourced/engine/engine.py
@@ -28,7 +28,15 @@ class Engine(object):
         self.__jvm = self.session.sparkContext._gateway.jvm
         java_import(self.__jvm, 'tech.sourced.engine.Engine')
         java_import(self.__jvm, 'tech.sourced.engine.package$')
-        self.__engine = self.__jvm.tech.sourced.engine.Engine.apply(self.__jsparkSession, repos_path)
+
+        try:
+            self.__engine = self.__jvm.tech.sourced.engine.Engine.apply(self.__jsparkSession, repos_path)
+        except TypeError as e:
+            if 'JavaPackage' in e.message:
+                raise Exception("package \"tech.sourced:engine:<version>\" cannot be found. Please, provide a jar with the package or install the package using --packages")
+            else:
+                raise e
+
         if skip_cleanup:
             self.__engine.skipCleanup(True)
         self.__implicits = getattr(getattr(self.__jvm.tech.sourced.engine, 'package$'), 'MODULE$')
@@ -117,7 +125,7 @@ def _custom_df_instance(func):
 
 class SourcedDataFrame(DataFrame):
     """
-    Custom source{d} Engine DataFrame that contains some DataFrame overriden methods and 
+    Custom source{d} Engine DataFrame that contains some DataFrame overriden methods and
     utilities. This class should not be used directly, please get your SourcedDataFrames
     using the provided methods.
 


### PR DESCRIPTION
Closes #160 
Closes #162 

As flaky as this might seem, there is nothing in the Py4J API to check if something imported does actually exist or not and all it throws is a `TypeError` so that's our best guess.