### PR TITLE
Link to external doc instead of repeating instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,64 +25,13 @@ $ ./bin/spark-shell --packages "tech.sourced:engine:[version]"
 $ ./bin/pyspark --packages "tech.sourced:engine:[version]"
 ```
 
-Run [bblfsh daemon](https://github.com/bblfsh/bblfshd):
+Run [bblfsh daemon](https://github.com/bblfsh/bblfshd). You can start it easily in a container following its [quick start guide](https://github.com/jfontan/bblfshd#quick-start).
 
-    docker create --rm --name bblfshd --privileged -p 9432:9432 -v /var/lib/bblfshd:/var/lib/bblfshd bblfsh/bblfshd:v2.1.2
-
-Then, execute the container:
-
-    docker start bblfshd
-
-Install bblfsh drivers:
-
-    docker exec -it bblfshd bblfshctl driver install --all
 
 # Pre-requisites
 
-## Apache Spark Installation
-
-First, you need to download [Apache Spark](https://spark.apache.org/) somewhere on your machine:
-
-```bash
-$ cd /tmp && wget "https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=spark/spark-2.2.0/spark-2.2.0-bin-hadoop2.7.tgz" -O spark-2.2.0-bin-hadoop2.7.tgz
-```
-The Apache Software Foundation suggests you the better mirror where you can download `Spark` from. If you wish to take a look and find the best option in your case, you can [do it here](https://www.apache.org/dyn/closer.lua/spark/spark-2.2.0/spark-2.2.0-bin-hadoop2.7.tgz).
-
-Then you must extract `Spark` from the downloaded tar file:
-
-```bash
-$ tar -C ~/ -xvzf spark-2.2.0-bin-hadoop2.7.tgz
-```
-Binaries and scripts to run `Spark` are located in spark-2.2.0-bin-hadoop2.7/bin, so maybe you would like to add it to your `PATH`:
-
-```bash
-$ export PATH=$PATH:$HOME/spark-2.2.0-bin-hadoop2.7/bin
-```
-
-or just set `SPARK_HOME` and run it as following:
-
-```bash
-$ export SPARK_HOME=$HOME/spark-2.2.0-bin-hadoop2.7
-$ $SPARK_HOME/bin/spark-shell
-```
-
-## bblfsh
-
-If you want to be able to use the UAST extraction features **engine** provides, you must run a [bblfsh daemon](https://github.com/bblfsh/bblfshd). You can do it easily with docker
-
-    docker create --rm --name bblfshd --privileged -p 9432:9432 -v /var/lib/bblfshd:/var/lib/bblfshd bblfsh/bblfshd:v2.1.2
-
-Now, execute the container:
-
-    docker start bblfshd
-
-Then you need to install bblfsh drivers to parse different languages, you should do this the first time you run the [bblfsh daemon](https://github.com/bblfsh/bblfshd):
-
-    docker exec -it bblfshd bblfshctl driver install --all
-
-You should be able to see the installed drivers running:
-
-    docker exec -it bblfshd bblfshctl driver list
+* [Apache Spark Installation](http://spark.apache.org/docs/latest/)
+* [bblfsh](https://github.com/bblfsh/bblfshd): Used for UAST extraction
 
 # Examples of engine usage
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ $ ./bin/spark-shell --packages "tech.sourced:engine:[version]"
 $ ./bin/pyspark --packages "tech.sourced:engine:[version]"
 ```
 
-Run [bblfsh daemon](https://github.com/bblfsh/bblfshd). You can start it easily in a container following its [quick start guide](https://github.com/jfontan/bblfshd#quick-start).
+Run [bblfsh daemon](https://github.com/bblfsh/bblfshd). You can start it easily in a container following its [quick start guide](https://github.com/bblfsh/bblfshd#quick-start).
 
 
 # Pre-requisites

--- a/README.md
+++ b/README.md
@@ -14,15 +14,34 @@ Current implementation combines:
 
 # Quick-start
 
+First, you need to download [Apache Spark](https://spark.apache.org/) somewhere on your machine:
+
+```bash
+$ cd /tmp && wget "https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=spark/spark-2.2.0/spark-2.2.0-bin-hadoop2.7.tgz" -O spark-2.2.0-bin-hadoop2.7.tgz
+```
+The Apache Software Foundation suggests you the better mirror where you can download `Spark` from. If you wish to take a look and find the best option in your case, you can [do it here](https://www.apache.org/dyn/closer.lua/spark/spark-2.2.0/spark-2.2.0-bin-hadoop2.7.tgz).
+
+Then you must extract `Spark` from the downloaded tar file:
+
+```bash
+$ tar -C ~/ -xvzf spark-2.2.0-bin-hadoop2.7.tgz
+```
+
+Binaries and scripts to run `Spark` are located in spark-2.2.0-bin-hadoop2.7/bin, so should set `PATH` and `SPARK_HOME` to point to this directory. It's advised to add this to your shell profile:
+
+```bash
+$ export SPARK_HOME=$HOME/spark-2.2.0-bin-hadoop2.7
+$ export PATH=$PATH:$SPARK_HOME/bin
+```
+
 Look for the latest [**engine** version](http://search.maven.org/#search%7Cga%7C1%7Ctech.sourced), and then replace in the command where `[version]` is showed:
 
 ```bash
-$ wget "https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=spark/spark-2.2.0/spark-2.2.0-bin-hadoop2.7.tgz" -O spark-2.2.0-bin-hadoop2.7.tgz
-$ tar -xzf spark-2.2.0-bin-hadoop2.7.tgz; cd spark-2.2.0-bin-hadoop2.7
-$ ./bin/spark-shell --packages "tech.sourced:engine:[version]"
+$ spark-shell --packages "tech.sourced:engine:[version]"
 
 # or
-$ ./bin/pyspark --packages "tech.sourced:engine:[version]"
+
+$ pyspark --packages "tech.sourced:engine:[version]"
 ```
 
 Run [bblfsh daemon](https://github.com/bblfsh/bblfshd). You can start it easily in a container following its [quick start guide](https://github.com/bblfsh/bblfshd#quick-start).

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Run [bblfsh daemon](https://github.com/bblfsh/bblfshd). You can start it easily 
 
 # Pre-requisites
 
-* [Apache Spark Installation](http://spark.apache.org/docs/latest/)
+* [Apache Spark Installation](http://spark.apache.org/docs/latest/) >= 2.2.0
 * [bblfsh](https://github.com/bblfsh/bblfshd): Used for UAST extraction
 
 # Examples of engine usage


### PR DESCRIPTION
Prerequisites is now a list with links to the projects. In quick start guide the instructions to download and run spark-shell are left in README as I have not found a quick guide to do that in the documentation.