### PR TITLE
[WIP] engine: read and save from and to external sources

### DIFF
--- a/src/main/scala/tech/sourced/engine/Schema.scala
+++ b/src/main/scala/tech/sourced/engine/Schema.scala
@@ -67,4 +67,12 @@ private[engine] object Schema {
       Nil
   )
 
+  val trees = StructType(
+    StructField("commit_hash", StringType, nullable = false) ::
+      StructField("path", StringType, nullable = false) ::
+      StructField("object_id", StringType, nullable = false) ::
+
+      Nil
+  )
+
 }


### PR DESCRIPTION

### implement tree entity and backToSource

This commit introduces the tree entity that can be obtained using getDataSource. For now, "trees" is a special case inside getDataSource, but in future commits it will be transformed to a regular iterator and will be included as a first class citizen in the engine.
Also introduces the backToSource method of the Engine class itself that will save all the data to an external data source, such as JSON, CSV or JDBC.
The API is still a little rough, but it's a good first approach to this that is currently working to start getting our hands on this.

### Notes

This is still in very early stage, but I'm publishing the PR to start getting feedback about it.

### Pending tasks

- [ ] Move trees to its own iterator if you guys think it's worth it instead of being special cased inside `getDataSource`.
- [ ] Provide higher-level API for JDBC and JSON.
- [ ] Implement reading from external datasource and use our datasource only for getting file blobs
- [ ] Figure out if we need CSV, because it would need some changes to the data (no arrays supported).