### PR TITLE
Reuse bblfsh client instead of creating one per call

### DIFF
--- a/src/main/scala/tech/sourced/engine/util/Bblfsh.scala
+++ b/src/main/scala/tech/sourced/engine/util/Bblfsh.scala
@@ -19,7 +19,7 @@ object Bblfsh {
 
   private val defaultPort = 9432
   private val defaultHost = "0.0.0.0"
-  private var client: BblfshClient = null
+  private var client: BblfshClient = _
 
   /**
     * Returns the configuration for babelfish.
@@ -40,7 +40,10 @@ object Bblfsh {
     * @return client
     */
   def getClient(config: Config): BblfshClient = synchronized {
-    if (client == null) client = BblfshClient(config.host, config.port)
+    if (client == null) {
+      client = BblfshClient(config.host, config.port)
+    }
+
     client
   }
 

--- a/src/main/scala/tech/sourced/engine/util/Bblfsh.scala
+++ b/src/main/scala/tech/sourced/engine/util/Bblfsh.scala
@@ -19,6 +19,7 @@ object Bblfsh {
 
   private val defaultPort = 9432
   private val defaultHost = "0.0.0.0"
+  private var client: BblfshClient = null
 
   /**
     * Returns the configuration for babelfish.
@@ -38,6 +39,9 @@ object Bblfsh {
     * @param config configuration for bblfsh
     * @return client
     */
-  def getClient(config: Config): BblfshClient = BblfshClient(config.host, config.port)
+  def getClient(config: Config): BblfshClient = synchronized {
+    if (client == null) client = BblfshClient(config.host, config.port)
+    client
+  }
 
 }


### PR DESCRIPTION
Closes #168 

Current implementation creates one client per call. In cases where the
connections are closed at an slower pace than they are created it can
reach user limits and give errors.

This change creates a new client object the first time it is called and
returns it in the next calls.