### PR TITLE
implement ENIP-001

### DIFF
--- a/src/main/scala/tech/sourced/engine/DefaultSource.scala
+++ b/src/main/scala/tech/sourced/engine/DefaultSource.scala
@@ -13,7 +13,7 @@ import tech.sourced.engine.util.Filter
 /**
   * Default source to provide new git relations.
   */
-class GitDataSource extends RelationProvider with DataSourceRegister {
+class DefaultSource extends RelationProvider with DataSourceRegister {
 
   /** @inheritdoc*/
   override def shortName: String = "git"
@@ -22,7 +22,7 @@ class GitDataSource extends RelationProvider with DataSourceRegister {
   override def createRelation(sqlContext: SQLContext,
                               parameters: Map[String, String]): BaseRelation = {
     val table = parameters.getOrElse(
-      GitDataSource.tableNameKey,
+      DefaultSource.tableNameKey,
       throw new SparkException("parameter 'table' must be provided")
     )
 
@@ -40,9 +40,9 @@ class GitDataSource extends RelationProvider with DataSourceRegister {
 }
 
 /**
-  * Just contains some useful constants for the GitDataSource class to use.
+  * Just contains some useful constants for the DefaultSource class to use.
   */
-object GitDataSource {
+object DefaultSource {
   val tableNameKey = "table"
   val pathKey = "path"
 
@@ -50,7 +50,7 @@ object GitDataSource {
 
   def register(session: SparkSession): Unit = {
     tables.foreach(t => {
-      session.read.format(gitDataSource)
+      session.read.format(defaultSource)
         .option(tableNameKey, t)
         .load(session.sqlContext.getConf(repositoriesPathKey))
         .createOrReplaceTempView(t)

--- a/src/main/scala/tech/sourced/engine/Engine.scala
+++ b/src/main/scala/tech/sourced/engine/Engine.scala
@@ -40,7 +40,7 @@ class Engine(session: SparkSession, repositoriesPath: String) {
   this.setRepositoriesPath(repositoriesPath)
   session.registerUDFs()
   session.experimental.extraOptimizations = Seq(SquashGitRelationJoin)
-  GitDataSource.register(session)
+  DefaultSource.register(session)
 
   // Options for a DataSource.
   type Options = Map[String, String]
@@ -56,9 +56,9 @@ class Engine(session: SparkSession, repositoriesPath: String) {
 
   /**
     * Loads the metadata from the given source and will use it to read the data instead
-    * of using the GitDataSource as much as possible.
+    * of using the DefaultSource as much as possible.
     *
-    * @param source               name of the format (e.g. "jdbc", "json", "csv", ...)
+    * @param source               name of the format (e.g. "jdbc", "json", "parquet", ...)
     * @param tableOptionsProvider function that given a table name will return
     *                             options for said table.
     * @param globalOptions        options that will be used regardless of the table name.
@@ -77,9 +77,9 @@ class Engine(session: SparkSession, repositoriesPath: String) {
   }
 
   /**
-    * Saves all the metadata of the GitDataSource into another data source.
+    * Saves all the metadata of the DefaultSource into another data source.
     *
-    * @param source               name of the format (e.g. "jdbc", "json", "csv", ...)
+    * @param source               name of the format (e.g. "jdbc", "json", "parquet", ...)
     * @param tableOptionsProvider function that given a table name will return
     *                             options for said table.
     * @param globalOptions        options that will be used regardless of the table name.

--- a/src/main/scala/tech/sourced/engine/Engine.scala
+++ b/src/main/scala/tech/sourced/engine/Engine.scala
@@ -35,10 +35,65 @@ import scala.collection.JavaConversions.asScalaBuffer
   * @constructor creates a Engine instance with the given Spark session.
   * @param session Spark session to be used
   */
-class Engine(session: SparkSession) {
+class Engine(session: SparkSession, repositoriesPath: String) {
 
+  this.setRepositoriesPath(repositoriesPath)
   session.registerUDFs()
   session.experimental.extraOptimizations = Seq(SquashGitRelationJoin)
+  GitDataSource.register(session)
+
+  // Options for a DataSource.
+  type Options = Map[String, String]
+
+  /**
+    * Function that will return options for the DataSource based on the received
+    * table name.
+    */
+  type TableOptionsProvider = (String) => Options
+
+  // TODO: tree entries and blobs are not yet supported
+  private val metadataTables = Seq("repositories", "references", "commits")
+
+  /**
+    * Loads the metadata from the given source and will use it to read the data instead
+    * of using the GitDataSource as much as possible.
+    *
+    * @param source               name of the format (e.g. "jdbc", "json", "csv", ...)
+    * @param tableOptionsProvider function that given a table name will return
+    *                             options for said table.
+    * @param globalOptions        options that will be used regardless of the table name.
+    */
+  def fromMetadataSource(source: String,
+                         tableOptionsProvider: TableOptionsProvider,
+                         globalOptions: Options = Map()): Engine = {
+    metadataTables.foreach(t => {
+      val reader = session.read.format(source)
+      (globalOptions ++ tableOptionsProvider(t))
+        .foldLeft(reader) { case (r, (k, v)) => r.option(k, v) }
+        .load()
+        .createOrReplaceTempView(t)
+    })
+    this
+  }
+
+  /**
+    * Saves all the metadata of the GitDataSource into another data source.
+    *
+    * @param source               name of the format (e.g. "jdbc", "json", "csv", ...)
+    * @param tableOptionsProvider function that given a table name will return
+    *                             options for said table.
+    * @param globalOptions        options that will be used regardless of the table name.
+    */
+  def backToMetadataSource(source: String,
+                           tableOptionsProvider: TableOptionsProvider,
+                           globalOptions: Options = Map()): Unit = {
+    metadataTables.foreach(t => {
+      val writer = session.table(t).write.format(source)
+      (globalOptions ++ tableOptionsProvider(t))
+        .foldLeft(writer) { case (w, (k, v)) => w.option(k, v) }
+        .save()
+    })
+  }
 
   /**
     * Returns a DataFrame with the data about the repositories found at
@@ -53,7 +108,7 @@ class Engine(session: SparkSession) {
     *
     * @return DataFrame
     */
-  def getRepositories: DataFrame = getDataSource("repositories", session)
+  def getRepositories: DataFrame = session.table("repositories")
 
   /**
     * Retrieves the files of a list of repositories, reference names and commit hashes.
@@ -181,8 +236,6 @@ object Engine {
     * @param repositoriesPath the path to the repositories' siva files
     * @return Engine instance
     */
-  def apply(session: SparkSession, repositoriesPath: String): Engine = {
-    new Engine(session)
-      .setRepositoriesPath(repositoriesPath)
-  }
+  def apply(session: SparkSession, repositoriesPath: String): Engine =
+    new Engine(session, repositoriesPath)
 }

--- a/src/main/scala/tech/sourced/engine/package.scala
+++ b/src/main/scala/tech/sourced/engine/package.scala
@@ -41,7 +41,7 @@ package object engine {
     */
   private[engine] val skipCleanupKey = "spark.tech.sourced.engine.cleanup.skip"
 
-  val gitDataSource = "tech.sourced.engine.GitDataSource"
+  val defaultSource = "tech.sourced.engine"
 
   // The keys repositoriesPathKey, bblfshHostKey, bblfshPortKey and skipCleanupKey must
   // start by "spark." to be able to be loaded from the "spark-defaults.conf" file.

--- a/src/main/scala/tech/sourced/engine/package.scala
+++ b/src/main/scala/tech/sourced/engine/package.scala
@@ -41,6 +41,8 @@ package object engine {
     */
   private[engine] val skipCleanupKey = "spark.tech.sourced.engine.cleanup.skip"
 
+  val gitDataSource = "tech.sourced.engine.GitDataSource"
+
   // The keys repositoriesPathKey, bblfshHostKey, bblfshPortKey and skipCleanupKey must
   // start by "spark." to be able to be loaded from the "spark-defaults.conf" file.
 
@@ -97,7 +99,7 @@ package object engine {
     def getReferences: DataFrame = {
       checkCols(df, "id")
       val reposIdsDf = df.select($"id")
-      getDataSource("references", df.sparkSession)
+      df.sparkSession.table("references")
         .join(reposIdsDf, $"repository_id" === $"id")
         .drop($"id")
     }
@@ -117,7 +119,7 @@ package object engine {
     def getCommits: DataFrame = {
       checkCols(df, "repository_id")
       val refsIdsDf = df.select($"name", $"repository_id")
-      val commitsDf = getDataSource("commits", df.sparkSession)
+      val commitsDf = df.sparkSession.table("commits")
       commitsDf.join(refsIdsDf, refsIdsDf("repository_id") === commitsDf("repository_id") &&
         commitsDf("reference_name") === refsIdsDf("name"))
         .drop(refsIdsDf("name")).drop(refsIdsDf("repository_id"))
@@ -156,7 +158,7 @@ package object engine {
       * @return new DataFrame containing also files data.
       */
     def getFiles: DataFrame = {
-      val filesDf = getDataSource("files", df.sparkSession)
+      val filesDf = df.sparkSession.table("files")
 
       if (df.schema.fieldNames.contains("index")) {
         val commitsDf = df.select("hash")
@@ -325,19 +327,6 @@ package object engine {
     }
 
   }
-
-  /**
-    * Returns a [[org.apache.spark.sql.DataFrame]] for the given table using the provided
-    * [[org.apache.spark.sql.SparkSession]].
-    *
-    * @param table   name of the table
-    * @param session spark session
-    * @return dataframe for the given table
-    */
-  private[engine] def getDataSource(table: String, session: SparkSession): DataFrame =
-    session.read.format("tech.sourced.engine.DefaultSource")
-      .option("table", table)
-      .load(session.sqlContext.getConf(repositoriesPathKey))
 
   /**
     * Ensures the given [[org.apache.spark.sql.DataFrame]] contains some required columns.

--- a/src/test/scala/tech/sourced/engine/EngineSpec.scala
+++ b/src/test/scala/tech/sourced/engine/EngineSpec.scala
@@ -51,7 +51,7 @@ class EngineSpec extends FlatSpec with Matchers with BaseSivaSpec with BaseSpark
     )
 
     // if fromMetadataSource does not load the metadata, it will use the ones from
-    // the GitDataSource and the result will be wrong
+    // the DefaultSource and the result will be wrong
     ss.table("repositories").createOrReplaceTempView("repos_tmp")
     ss.table("commits").createOrReplaceTempView("repositories")
     ss.table("references").createOrReplaceTempView("commits")

--- a/src/test/scala/tech/sourced/engine/EngineSpec.scala
+++ b/src/test/scala/tech/sourced/engine/EngineSpec.scala
@@ -1,0 +1,73 @@
+package tech.sourced.engine
+
+import java.io.File
+import java.nio.file.Files
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class EngineSpec extends FlatSpec with Matchers with BaseSivaSpec with BaseSparkSpec {
+
+  var engine: Engine = _
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+
+    engine = Engine(ss, resourcePath)
+  }
+
+  "backToMetadataSource" should "back to other sources" in {
+    val tmpDir = Files.createTempDirectory("engine-back")
+
+    engine.backToMetadataSource(
+      "json",
+      table => Map("path" -> new File(tmpDir.toString, table).getAbsolutePath)
+    )
+
+    val assertExistsBackup = (table: String) => {
+      val f = new File(tmpDir.toString, table)
+      f.exists() should be(true)
+      f.isDirectory should be(true)
+    }
+
+    val assertCount = (table: String) => {
+      val f = new File(tmpDir.toString, table)
+      val df = ss.table(table)
+      val jsonDf = ss.read.json(f.getAbsolutePath)
+      jsonDf.count() should be(df.count())
+    }
+
+    val tables = Seq("repositories", "references", "commits")
+
+    tables.foreach(assertExistsBackup)
+    tables.foreach(assertCount)
+  }
+
+  "fromMetadataSource" should "use metadata source" in {
+    val tmpDir = Files.createTempDirectory("engine-back")
+
+    engine.backToMetadataSource(
+      "json",
+      table => Map("path" -> new File(tmpDir.toString, table).getAbsolutePath)
+    )
+
+    // if fromMetadataSource does not load the metadata, it will use the ones from
+    // the GitDataSource and the result will be wrong
+    ss.table("repositories").createOrReplaceTempView("repos_tmp")
+    ss.table("commits").createOrReplaceTempView("repositories")
+    ss.table("references").createOrReplaceTempView("commits")
+    ss.table("repos_tmp").createOrReplaceTempView("references")
+
+    val reposDf = engine.fromMetadataSource(
+      "json",
+      table => Map("path" -> new File(tmpDir.toString, table).getAbsolutePath)
+    ).getRepositories
+    reposDf.count() should be(5)
+
+    val refsDf = reposDf.getReferences
+    refsDf.count() should be(56)
+
+    val commitsDf = refsDf.getCommits
+    commitsDf.count() should be(4444)
+  }
+
+}

--- a/src/test/scala/tech/sourced/engine/GitDataSourceSpec.scala
+++ b/src/test/scala/tech/sourced/engine/GitDataSourceSpec.scala
@@ -2,7 +2,7 @@ package tech.sourced.engine
 
 import org.scalatest._
 
-class DefaultSourceSpec extends FlatSpec with Matchers with BaseSivaSpec with BaseSparkSpec {
+class GitDataSourceSpec extends FlatSpec with Matchers with BaseSivaSpec with BaseSparkSpec {
 
   var engine: Engine = _
 
@@ -12,7 +12,7 @@ class DefaultSourceSpec extends FlatSpec with Matchers with BaseSivaSpec with Ba
     engine = Engine(ss, resourcePath)
   }
 
-  "Default source" should "get heads of all repositories and count the files" in {
+  "Git data source" should "get heads of all repositories and count the files" in {
     val df = engine.getRepositories.getHEAD.getCommits.getFirstReferenceCommit.getFiles
     engine.getRepositories.getHEAD.getCommits.getFirstReferenceCommit.show
     df.show(457)
@@ -49,12 +49,11 @@ class DefaultSourceSpec extends FlatSpec with Matchers with BaseSivaSpec with Ba
   it should "not optimize if the conditions on the " +
     "join are not the expected ones" in {
     val repos = engine.getRepositories
-    val references = ss.read.format("tech.sourced.engine").option("table", "references").load()
+    val references = ss.read.format(gitDataSource).option("table", "references").load()
     val out = repos.join(references,
       (references("repository_id") === repos("id"))
         .and(references("name").startsWith("refs/pull"))
     ).count()
-
 
     info("Files/blobs with commit hashes:\n")
     val filesDf = references.getCommits.getFiles.select(

--- a/src/test/scala/tech/sourced/engine/GitDataSourceSpec.scala
+++ b/src/test/scala/tech/sourced/engine/GitDataSourceSpec.scala
@@ -49,7 +49,7 @@ class GitDataSourceSpec extends FlatSpec with Matchers with BaseSivaSpec with Ba
   it should "not optimize if the conditions on the " +
     "join are not the expected ones" in {
     val repos = engine.getRepositories
-    val references = ss.read.format(gitDataSource).option("table", "references").load()
+    val references = ss.read.format(defaultSource).option("table", "references").load()
     val out = repos.join(references,
       (references("repository_id") === repos("id"))
         .and(references("name").startsWith("refs/pull"))


### PR DESCRIPTION
This PR implements the ENgine Improvement Proposal 1 (#186) and includes the following changes:
* Renames the DefaultSource to GitDataSource.
* Engine constructor now requires a repositories path.
* The tables are registered as view in the session as soon as the Engine is instantiated.
* Added API to load from and save to other datasources.