### PR TITLE
Fix NPE when persist DF to disk

### DIFF
--- a/src/main/scala/tech/sourced/engine/DefaultSource.scala
+++ b/src/main/scala/tech/sourced/engine/DefaultSource.scala
@@ -128,6 +128,7 @@ case class GitRelation(session: SparkSession,
         case other => throw new SparkException(s"required cols for '$other' is not supported")
       })
 
+      // FIXME: when the RDD is persisted to disk the last element of this iterator is closed twice
       new CleanupIterator(iter.getOrElse(Seq().toIterator), provider.close(pds, repo))
     })
   }

--- a/src/main/scala/tech/sourced/engine/provider/RepositoryProvider.scala
+++ b/src/main/scala/tech/sourced/engine/provider/RepositoryProvider.scala
@@ -73,7 +73,14 @@ class RepositoryProvider(val localPath: String, val skipCleanup: Boolean = false
     logDebug(s"Closing repository. active/idle count: " +
       s"${repositoryPool.getNumActive(key)}/ " +
       s"${repositoryPool.getNumIdle(key)}")
-    repositoryPool.returnObject(key, repo)
+
+    if (repositoryPool.getNumActive(key) != 0) {
+      repositoryPool.returnObject(key, repo)
+    } else {
+      logWarning(s"closing repository at ${repo.getDirectory};" +
+        s" returning object to the pool failed because it was already returned")
+    }
+
     if (repositoryPool.getNumActive == 0) {
       logDebug("No active elements on the pool, clearing all.")
       repositoryPool.clear()

--- a/src/test/scala/tech/sourced/engine/DefaultSourceSpec.scala
+++ b/src/test/scala/tech/sourced/engine/DefaultSourceSpec.scala
@@ -66,6 +66,26 @@ class DefaultSourceSpec extends FlatSpec with Matchers with BaseSivaSpec with Ba
     out should be(37)
   }
 
+  it should "work with all storage levels" in {
+    import org.apache.spark.storage.StorageLevel._
+    val storageLevels = List(
+      DISK_ONLY,
+      DISK_ONLY_2,
+      MEMORY_AND_DISK,
+      MEMORY_AND_DISK_2,
+      MEMORY_AND_DISK_SER,
+      MEMORY_AND_DISK_SER_2,
+      MEMORY_ONLY,
+      MEMORY_ONLY_2,
+      MEMORY_ONLY_SER,
+      MEMORY_ONLY_SER_2,
+      NONE,
+      OFF_HEAP
+    )
+
+    storageLevels.foreach(engine.getRepositories.persist(_).count)
+  }
+
   "Convenience for getting files" should "work without reading commits" in {
     val spark = ss
     import spark.implicits._


### PR DESCRIPTION
***This PR is related to #177***

The changes avoid to return an object to the pool which was already returned.

I don't know why, but when the DF is persisted to disk, the last repo in the RDD generated by the `BaseRelation.buildScan` is closed twice. Because of this, the NPE was thrown.

@ajnavarro @erizocosmico @jfontan do you know what is causing this behavior?