### PR TITLE
*: split files table into tree_entries and blobs

### DIFF
--- a/_examples/notebooks/Example.ipynb
+++ b/_examples/notebooks/Example.ipynb
@@ -43,7 +43,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Get all the files of all head commits"
+    "### Get all the blobs of all head commits"
    ]
   },
   {
@@ -54,9 +54,9 @@
    },
    "outputs": [],
    "source": [
-    "head_files = engine.repositories.filter(\"is_fork = false\").references\\\n",
+    "head_blobs = engine.repositories.filter(\"is_fork = false\").references\\\n",
     ".head_ref.commits.first_reference_commit\\\n",
-    ".files\\\n",
+    ".tree_entries.blobs\\\n",
     ".classify_languages()\\\n",
     ".filter(\"is_binary = false\")\\\n",
     ".select(\"file_hash\", \"path\", \"content\", \"lang\").filter(\"lang is not null\").cache()"
@@ -77,7 +77,7 @@
    },
    "outputs": [],
    "source": [
-    "head_files.printSchema()"
+    "head_blobs.printSchema()"
    ]
   },
   {
@@ -95,14 +95,14 @@
    },
    "outputs": [],
    "source": [
-    "head_files.show()"
+    "head_blobs.show()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Top languages per number of files"
+    "### Top languages per number of blobs"
    ]
   },
   {
@@ -113,7 +113,7 @@
    },
    "outputs": [],
    "source": [
-    "top_ten_langs = head_files.distinct()\\\n",
+    "top_ten_langs = head_blobs.distinct()\\\n",
     ".groupBy(\"lang\").agg(count(\"*\").alias(\"count\"))\\\n",
     ".orderBy(\"count\").sort(desc(\"count\")).limit(10)\\\n",
     ".show()"
@@ -125,7 +125,7 @@
     "collapsed": true
    },
    "source": [
-    "### Get all Java files"
+    "### Get all Java blobs"
    ]
   },
   {
@@ -136,7 +136,7 @@
    },
    "outputs": [],
    "source": [
-    " head_files.groupBy(\"lang\").agg(count(\"*\").alias(\"count\")).filter(\"lang='Java'\").show()"
+    " head_blobs.groupBy(\"lang\").agg(count(\"*\").alias(\"count\")).filter(\"lang='Java'\").show()"
    ]
   },
   {
@@ -147,14 +147,14 @@
    },
    "outputs": [],
    "source": [
-    "head_files.limit(10).show()"
+    "head_blobs.limit(10).show()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Get identifiers of all Python files"
+    "### Get identifiers of all Python blobs"
    ]
   },
   {
@@ -167,7 +167,7 @@
    "source": [
     "idents = engine.repositories.filter(\"is_fork = false\").references\\\n",
     ".head_ref.commits.first_reference_commit\\\n",
-    ".files\\\n",
+    ".tree_entries.blobs\\\n",
     ".classify_languages()\\\n",
     ".extract_uasts()\\\n",
     ".query_uast('//*[@roleIdentifier and not(@roleIncomplete)]')\\\n",

--- a/_examples/pyspark/pyspark-shell-basic.md
+++ b/_examples/pyspark/pyspark-shell-basic.md
@@ -4,7 +4,7 @@ In this example, the pyspark-shell is used to show a simple usage of the `source
 
 First, you can see how to import the package and instantiate and object that provide all the methods to manipulate the data retrieved from repositories.
 
-The `engine` object is used to get all the repositories, get the `HEAD` references from the repositories and eventually, get all the files from these references. Then a table is showed selecting the columns `file_hash`, `path` and `content`.
+The `engine` object is used to get all the repositories, get the `HEAD` references from the repositories and eventually, get all the blobs from these references. Then a table is showed selecting the columns `file_hash`, `path` and `content`.
 
 Launch pyspark-shell, replacing `[version]` with the [latest engine version](http://search.maven.org/#search%7Cga%7C1%7Ctech.sourced):
 ```sh
@@ -15,11 +15,11 @@ Code
 ```python
 from sourced.engine import Engine
 engine = Engine(spark, '/path/to/siva-files')
-engine.repositories.references.head_ref.files.select('file_hash', 'path', 'content').show()
+engine.repositories.references.head_ref.commits.tree_entries.blobs.select('blob_id', 'path', 'content').show()
 
 ''' Output:
 +--------------------+--------------------+--------------------+
-|           file_hash|                path|             content|
+|           blob_id  |                path|             content|
 +--------------------+--------------------+--------------------+
 |ff4fa0794274a7ffb...|fibonacci/fibonac...|[64 65 66 20 66 6...|
 |7268016814b8ab7bc...|          gcd/gcd.py|[69 6D 70 6F 72 7...|

--- a/_examples/pyspark/pyspark-shell-basic.md
+++ b/_examples/pyspark/pyspark-shell-basic.md
@@ -4,7 +4,7 @@ In this example, the pyspark-shell is used to show a simple usage of the `source
 
 First, you can see how to import the package and instantiate and object that provide all the methods to manipulate the data retrieved from repositories.
 
-The `engine` object is used to get all the repositories, get the `HEAD` references from the repositories and eventually, get all the blobs from these references. Then a table is showed selecting the columns `file_hash`, `path` and `content`.
+The `engine` object is used to get all the repositories, get the `HEAD` references from the repositories and eventually, get all the blobs from these references. Then a table is showed selecting the columns `blob_id`, `path` and `content`.
 
 Launch pyspark-shell, replacing `[version]` with the [latest engine version](http://search.maven.org/#search%7Cga%7C1%7Ctech.sourced):
 ```sh

--- a/_examples/pyspark/pyspark-shell-classifying-languages.md
+++ b/_examples/pyspark/pyspark-shell-classifying-languages.md
@@ -1,8 +1,8 @@
 ## Classifying languages example
 
-This example uses the pyspark-shell to show how to classify files by their language with `classify_languages()`.
+This example uses the pyspark-shell to show how to classify blobs by their language with `classify_languages()`.
 
-Making use of the `engine` object, it retrieves repositories to get all files from the `HEAD` references from them. After that, a call to `classify_languages()` function detects the language for each file to show them in the aggregated column `lang` beside the selected columns `file_hash` and `path`.
+Making use of the `engine` object, it retrieves repositories to get all blobs from the `HEAD` references from them. After that, a call to `classify_languages()` function detects the language for each file to show them in the aggregated column `lang` beside the selected columns `file_hash` and `path`.
 
 Launch pyspark-shell, replacing `[version]` with the [latest engine version](http://search.maven.org/#search%7Cga%7C1%7Ctech.sourced):
 ```sh
@@ -13,11 +13,11 @@ Code:
 ```python
 from sourced.engine import Engine
 engine = Engine(spark, '/path/to/siva-files')
-engine.repositories.references.head_ref.files.classify_languages().select("file_hash", "path", "lang").show()
+engine.repositories.references.head_ref.commits.tree_entries.blobs.classify_languages().select("blob_id", "path", "lang").show()
 
 ''' Output:
 +--------------------+--------------------+--------+
-|           file_hash|                path|    lang|
+|             blob_id|                path|    lang|
 +--------------------+--------------------+--------+
 |ff4fa0794274a7ffb...|fibonacci/fibonac...|  Python|
 |7268016814b8ab7bc...|          gcd/gcd.py|  Python|

--- a/_examples/pyspark/pyspark-shell-classifying-languages.md
+++ b/_examples/pyspark/pyspark-shell-classifying-languages.md
@@ -2,7 +2,7 @@
 
 This example uses the pyspark-shell to show how to classify blobs by their language with `classify_languages()`.
 
-Making use of the `engine` object, it retrieves repositories to get all blobs from the `HEAD` references from them. After that, a call to `classify_languages()` function detects the language for each file to show them in the aggregated column `lang` beside the selected columns `file_hash` and `path`.
+Making use of the `engine` object, it retrieves repositories to get all blobs from the `HEAD` references from them. After that, a call to `classify_languages()` function detects the language for each file to show them in the aggregated column `lang` beside the selected columns `blob_id` and `path`.
 
 Launch pyspark-shell, replacing `[version]` with the [latest engine version](http://search.maven.org/#search%7Cga%7C1%7Ctech.sourced):
 ```sh

--- a/_examples/pyspark/pyspark-shell-lang-and-uast.md
+++ b/_examples/pyspark/pyspark-shell-lang-and-uast.md
@@ -13,7 +13,7 @@ Code:
 ```python
 from sourced.engine import Engine
 engine = Engine(spark, '/path/to/siva-files')
-engine.repositories.references.head_ref.files.classify_languages().extract_uasts().select("path", "lang", "uast").show()
+engine.repositories.references.head_ref.commits.tree_entries.blobs.classify_languages().extract_uasts().select("path", "lang", "uast").show()
 
 ''' Output:
 +--------------------+--------+-------------+

--- a/_examples/pyspark/pyspark-shell-schemas.md
+++ b/_examples/pyspark/pyspark-shell-schemas.md
@@ -41,11 +41,6 @@ root
  |-- message: string (nullable = false)
  |-- parents: array (nullable = true)
  |    |-- element: string (containsNull = false)
- |-- tree: map (nullable = true)
- |    |-- key: string
- |    |-- value: string (valueContainsNull = false)
- |-- blobs: array (nullable = true)
- |    |-- element: string (containsNull = false)
  |-- parents_count: integer (nullable = false)
  |-- author_email: string (nullable = true)
  |-- author_name: string (nullable = true)
@@ -55,33 +50,49 @@ root
  |-- committer_date: timestamp (nullable = true)
 '''
 
-engine.repositories.references.files.printSchema()
+engine.repositories.references.commits.tree_entries.printSchema()
 ''' Output:
 root
- |-- file_hash: string (nullable = false)
- |-- content: binary (nullable = true)
  |-- commit_hash: string (nullable = false)
+ |-- repository_id: string (nullable = false)
+ |-- reference_name: string (nullable = false)
+ |-- path: string (nullable = true)
+ |-- blob: string (nullable = false)
+'''
+
+engine.repositories.references.commits.tree_entries.blobs.printSchema()
+''' Output:
+root
+ |-- blob_id: string (nullable = false)
+ |-- commit_hash: string (nullable = false)
+ |-- repository_id: string (nullable = false)
+ |-- reference_name: string (nullable = false)
+ |-- content: binary (nullable = true)
  |-- is_binary: boolean (nullable = false)
  |-- path: string (nullable = true)
 '''
 
-engine.repositories.references.files.classify_languages().printSchema()
+engine.repositories.references.commits.tree_entries.blobs.classify_languages().printSchema()
 ''' Output:
 root
- |-- file_hash: string (nullable = false)
- |-- content: binary (nullable = true)
+ |-- blob_id: string (nullable = false)
  |-- commit_hash: string (nullable = false)
+ |-- repository_id: string (nullable = false)
+ |-- reference_name: string (nullable = false)
+ |-- content: binary (nullable = true)
  |-- is_binary: boolean (nullable = false)
  |-- path: string (nullable = true)
  |-- lang: string (nullable = true)
 '''
 
-engine.repositories.references.files.classify_languages().extract_uasts().printSchema()
+engine.repositories.references.commits.tree_entries.blobs.classify_languages().extract_uasts().printSchema()
 ''' Output:
 root
- |-- file_hash: string (nullable = false)
- |-- content: binary (nullable = true)
+ |-- blob_id: string (nullable = false)
  |-- commit_hash: string (nullable = false)
+ |-- repository_id: string (nullable = false)
+ |-- reference_name: string (nullable = false)
+ |-- content: binary (nullable = true)
  |-- is_binary: boolean (nullable = false)
  |-- path: string (nullable = true)
  |-- lang: string (nullable = true)

--- a/_examples/pyspark/pyspark-shell-uast-extraction.md
+++ b/_examples/pyspark/pyspark-shell-uast-extraction.md
@@ -2,9 +2,9 @@
 
 In the example code below, you can take a look to how the `extract_uasts()` method works.
 
-From the `engine` object instantiated in the spark-shell, a bunch of files are retrieving from the `HEAD` references from all the repositories and requesting for them. Once we have that files, we can call `extract_uasts()` which send the files to a [bblfsh server](https://github.com/bblfsh/server) to get back the UASTs.
+From the `engine` object instantiated in the spark-shell, a bunch of blobs are retrieving from the `HEAD` references from all the repositories and requesting for them. Once we have those blobs, we can call `extract_uasts()` which send the blobs to a [bblfsh server](https://github.com/bblfsh/server) to get back the UASTs.
 
-Finally, the `file_hash` , `path` and `uast` is showed on the table.
+Finally, the `blob_id` , `path` and `uast` is showed on the table.
 
 Launch pyspark-shell, replacing `[version]` with the [latest engine version](http://search.maven.org/#search%7Cga%7C1%7Ctech.sourced):
 ```sh
@@ -15,11 +15,11 @@ Code:
 ```python
 from sourced.engine import Engine
 engine = Engine(spark, '/path/to/siva-files')
-engine.repositories.references.head_ref.files.extract_uasts().select("file_hash", "path", "uast").show()
+engine.repositories.references.head_ref.commits.tree_entries.blobs.classify_languages().extract_uasts().select("blob_id", "path", "uast").show()
 
 ''' Output:
 +--------------------+--------------------+-------------+
-|           file_hash|                path|         uast|
+|             blob_id|                path|         uast|
 +--------------------+--------------------+-------------+
 |ff4fa0794274a7ffb...|fibonacci/fibonac...|[[B@43efe672]|
 |7268016814b8ab7bc...|          gcd/gcd.py|[[B@66938491]|

--- a/_examples/pyspark/pyspark-shell-xpath-query.md
+++ b/_examples/pyspark/pyspark-shell-xpath-query.md
@@ -18,11 +18,11 @@ Code:
 from sourced.engine import Engine
 engine = Engine(spark, '/path/to/siva-files')
 
-engine.repositories.references.head_ref.files.classify_languages().where('lang = "Python"').extract_uasts().query_uast('//*[@roleIdentifier]').extract_tokens('result', 'tokens').select('file_hash', 'path', 'lang', 'uast', 'tokens').show()
+engine.repositories.references.head_ref.commits.tree_entries.blobs.classify_languages().where('lang = "Python"').extract_uasts().query_uast('//*[@roleIdentifier]').extract_tokens('result', 'tokens').select('blob_id', 'path', 'lang', 'uast', 'tokens').show()
 
 ''' Output:
 +--------------------+--------------------+------+-------------+--------------------+
-|           file_hash|                path|  lang|         uast|              tokens|
+|             blob_id|                path|  lang|         uast|              tokens|
 +--------------------+--------------------+------+-------------+--------------------+
 |ff4fa0794274a7ffb...|fibonacci/fibonac...|Python|[[B@617b4738]|[fibonacci, n, in...|
 |7268016814b8ab7bc...|          gcd/gcd.py|Python|[[B@2c66d0f9]|[math, gcd, a, in...|

--- a/_examples/scala/spark-shell-classifying-languages.md
+++ b/_examples/scala/spark-shell-classifying-languages.md
@@ -1,8 +1,8 @@
 ## Classifying languages example
 
-This example uses the spark-shell to show how to classify files by their language with `classifyLanguages`.
+This example uses the spark-shell to show how to classify blobs by their language with `classifyLanguages`.
 
-Making use of the `engine` object, it filters repositories by `id` to get all files from the `HEAD` references from them. After that, a call to `classifyLanguages` function detects the language for each file to show them in the aggregated column `lang` beside the selected columns `file_hash` and `path`.
+Making use of the `engine` object, it filters repositories by `id` to get all blobs from the `HEAD` references from them. After that, a call to `classifyLanguages` function detects the language for each file to show them in the aggregated column `lang` beside the selected columns `file_hash` and `path`.
 
 Launch spark-shell, replacing `[version]` with the [latest engine version](http://search.maven.org/#search%7Cga%7C1%7Ctech.sourced):
 ```sh
@@ -14,11 +14,11 @@ Code:
 import tech.sourced.engine._
 
 val engine = Engine(spark, "/path/to/siva-files")
-engine.getRepositories.filter('id === "github.com/mingrammer/funmath.git").getHEAD.getFiles.classifyLanguages.select('file_hash, 'path, 'lang).show
+engine.getRepositories.filter('id === "github.com/mingrammer/funmath.git").getHEAD.getCommits.getTreeEntries.getBlobs.classifyLanguages.select('blob_id, 'path, 'lang).show
 
 /* Output:
 +--------------------+--------------------+--------+
-|           file_hash|                path|    lang|
+|             blob_id|                path|    lang|
 +--------------------+--------------------+--------+
 |ff4fa0794274a7ffb...|fibonacci/fibonac...|  Python|
 |7268016814b8ab7bc...|          gcd/gcd.py|  Python|

--- a/_examples/scala/spark-shell-classifying-languages.md
+++ b/_examples/scala/spark-shell-classifying-languages.md
@@ -2,7 +2,7 @@
 
 This example uses the spark-shell to show how to classify blobs by their language with `classifyLanguages`.
 
-Making use of the `engine` object, it filters repositories by `id` to get all blobs from the `HEAD` references from them. After that, a call to `classifyLanguages` function detects the language for each file to show them in the aggregated column `lang` beside the selected columns `file_hash` and `path`.
+Making use of the `engine` object, it filters repositories by `id` to get all blobs from the `HEAD` references from them. After that, a call to `classifyLanguages` function detects the language for each file to show them in the aggregated column `lang` beside the selected columns `blob_id` and `path`.
 
 Launch spark-shell, replacing `[version]` with the [latest engine version](http://search.maven.org/#search%7Cga%7C1%7Ctech.sourced):
 ```sh

--- a/_examples/scala/spark-shell-lang-and-uast.md
+++ b/_examples/scala/spark-shell-lang-and-uast.md
@@ -14,11 +14,11 @@ Code:
 import tech.sourced.engine._
 
 val engine = Engine(spark, "/path/to/siva-files")
-engine.getRepositories.getHEAD.getFiles.classifyLanguages.extractUASTs.select('file_hash, 'path, 'lang, 'uast).show
+engine.getRepositories.getHEAD.getCommits.getTreeEntries.getBlobs.classifyLanguages.extractUASTs.select('blob_id, 'path, 'lang, 'uast).show
 
 /* Output:
 +--------------------+--------------------+--------+-------------+
-|           file_hash|                path|    lang|         uast|
+|             blob_id|                path|    lang|         uast|
 +--------------------+--------------------+--------+-------------+
 |ff4fa0794274a7ffb...|fibonacci/fibonac...|  Python|[[B@62f37a44]|
 |7268016814b8ab7bc...|          gcd/gcd.py|  Python|[[B@7c0368da]|

--- a/_examples/scala/spark-shell-schemas.md
+++ b/_examples/scala/spark-shell-schemas.md
@@ -41,11 +41,6 @@ root
  |-- message: string (nullable = false)
  |-- parents: array (nullable = true)
  |    |-- element: string (containsNull = false)
- |-- tree: map (nullable = true)
- |    |-- key: string
- |    |-- value: string (valueContainsNull = false)
- |-- blobs: array (nullable = true)
- |    |-- element: string (containsNull = false)
  |-- parents_count: integer (nullable = false)
  |-- author_email: string (nullable = true)
  |-- author_name: string (nullable = true)
@@ -55,33 +50,48 @@ root
  |-- committer_date: timestamp (nullable = true)
 */
 
-engine.getRepositories.getReferences.getFiles.printSchema
+engine.getRepositories.getReferences.getCommits.getTreeEntries.printSchema
 /* Output:
 root
- |-- file_hash: string (nullable = false)
- |-- content: binary (nullable = true)
  |-- commit_hash: string (nullable = false)
+ |-- repository_id: string (nullable = false)
+ |-- reference_name: string (nullable = false)
+ |-- blob: string (nullable = true)
+*/
+
+engine.getRepositories.getReferences.getCommits.getTreeEntries.getBlobs.printSchema
+/* Output:
+root
+ |-- blob_id: string (nullable = false)
+ |-- commit_hash: string (nullable = false)
+ |-- repository_id: string (nullable = false)
+ |-- reference_name: string (nullable = false)
+ |-- content: binary (nullable = true)
  |-- is_binary: boolean (nullable = false)
  |-- path: string (nullable = true)
 */
 
-engine.getRepositories.getReferences.getFiles.classifyLanguages.printSchema
+engine.getRepositories.getReferences.getCommits.getTreeEntries.getBlobs.classifyLanguages.printSchema
 /* Output:
 root
- |-- file_hash: string (nullable = false)
- |-- content: binary (nullable = true)
+ |-- blob_id: string (nullable = false)
  |-- commit_hash: string (nullable = false)
+ |-- repository_id: string (nullable = false)
+ |-- reference_name: string (nullable = false)
+ |-- content: binary (nullable = true)
  |-- is_binary: boolean (nullable = false)
  |-- path: string (nullable = true)
  |-- lang: string (nullable = true)
 */
 
-engine.getRepositories.getReferences.getFiles.classifyLanguages.extractUASTs.printSchema
+engine.getRepositories.getReferences.getCommits.getTreeEntries.getBlobs.classifyLanguages.extractUASTs.printSchema
 /* Output:
 root
- |-- file_hash: string (nullable = false)
- |-- content: binary (nullable = true)
+ |-- blob_id: string (nullable = false)
  |-- commit_hash: string (nullable = false)
+ |-- repository_id: string (nullable = false)
+ |-- reference_name: string (nullable = false)
+ |-- content: binary (nullable = true)
  |-- is_binary: boolean (nullable = false)
  |-- path: string (nullable = true)
  |-- lang: string (nullable = true)

--- a/_examples/scala/spark-shell-uast-extraction.md
+++ b/_examples/scala/spark-shell-uast-extraction.md
@@ -4,7 +4,7 @@ In the example code below, you can take a look to how the `extractUASTs` method 
 
 From the `engine` object instantiated in the spark-shell, a bunch of blobs has been got filtering repositories by `id`, retrieving their `HEAD` references and requesting for them. Once we have that blobs, we can call `extractUASTs` which send the blobs to a [bblfsh server](https://github.com/bblfsh/server) to get back the UASTs.
 
-Finally, the `file_hash`, file `path` and `uast` is showed on the table.
+Finally, the `blob_id`, file `path` and `uast` is showed on the table.
 
 Launch spark-shell, replacing `[version]` with the [latest engine version](http://search.maven.org/#search%7Cga%7C1%7Ctech.sourced):
 ```sh

--- a/_examples/scala/spark-shell-uast-extraction.md
+++ b/_examples/scala/spark-shell-uast-extraction.md
@@ -2,7 +2,7 @@
 
 In the example code below, you can take a look to how the `extractUASTs` method works.
 
-From the `engine` object instantiated in the spark-shell, a bunch of files has been got filtering repositories by `id`, retrieving their `HEAD` references and requesting for them. Once we have that files, we can call `extractUASTs` which send the files to a [bblfsh server](https://github.com/bblfsh/server) to get back the UASTs.
+From the `engine` object instantiated in the spark-shell, a bunch of blobs has been got filtering repositories by `id`, retrieving their `HEAD` references and requesting for them. Once we have that blobs, we can call `extractUASTs` which send the blobs to a [bblfsh server](https://github.com/bblfsh/server) to get back the UASTs.
 
 Finally, the `file_hash`, file `path` and `uast` is showed on the table.
 
@@ -15,13 +15,13 @@ $ spark-shell --packages "tech.sourced:engine:[version]"
 import tech.sourced.engine._
 
 val engine = Engine(spark, "/path/to/siva-files")
-val exampleDf = engine.getRepositories.filter('id === "github.com/mingrammer/funmath.git").getHEAD.getFiles.extractUASTs.select('file_hash, 'path, 'uast)
+val exampleDf = engine.getRepositories.filter('id === "github.com/mingrammer/funmath.git").getHEAD.getCommits.getTreeEntries.getBlobs.extractUASTs.select('blob_id, 'path, 'uast)
 
 exampleDf.show
 
 /* Output:
 +--------------------+--------------------+-------------+
-|           file_hash|                path|         uast|
+|             blob_id|                path|         uast|
 +--------------------+--------------------+-------------+
 |ff4fa0794274a7ffb...|fibonacci/fibonac...|[[B@5e53daf6]|
 |7268016814b8ab7bc...|          gcd/gcd.py|[[B@65f08242]|

--- a/_examples/scala/spark-shell-xpath-query.md
+++ b/_examples/scala/spark-shell-xpath-query.md
@@ -18,7 +18,7 @@ Code:
 import tech.sourced.engine._
 
 val engine = Engine(spark, "/path/to/siva-files")
-engine.getRepositories.getHEAD.getFiles.classifyLanguages.where('lang === "Python").extractUASTs.queryUAST("//*[@roleIdentifier]", "uast", "result").extractTokens("result", "tokens").select('path, 'lang, 'uast, 'tokens).show
+engine.getRepositories.getHEAD.getCommits.getTreeEntries.getBlobs.classifyLanguages.where('lang === "Python").extractUASTs.queryUAST("//*[@roleIdentifier]", "uast", "result").extractTokens("result", "tokens").select('path, 'lang, 'uast, 'tokens).show
 
 /* Output:
 +--------------------+------+-------------+--------------------+

--- a/examples/notebooks/Example.ipynb
+++ b/examples/notebooks/Example.ipynb
@@ -43,7 +43,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Get all the files of all head commits"
+    "### Get all the blobs of all head commits"
    ]
   },
   {
@@ -54,9 +54,9 @@
    },
    "outputs": [],
    "source": [
-    "head_files = engine.repositories.filter(\"is_fork = false\").references\\\n",
+    "head_blobs = engine.repositories.filter(\"is_fork = false\").references\\\n",
     ".head_ref.commits.first_reference_commit\\\n",
-    ".files\\\n",
+    ".tree_entries.blobs\\\n",
     ".classify_languages()\\\n",
     ".filter(\"is_binary = false\")\\\n",
     ".select(\"file_hash\", \"path\", \"content\", \"lang\").filter(\"lang is not null\").cache()"
@@ -77,7 +77,7 @@
    },
    "outputs": [],
    "source": [
-    "head_files.printSchema()"
+    "head_blobs.printSchema()"
    ]
   },
   {
@@ -95,14 +95,14 @@
    },
    "outputs": [],
    "source": [
-    "head_files.show()"
+    "head_blobs.show()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Top languages per number of files"
+    "### Top languages per number of blobs"
    ]
   },
   {
@@ -113,7 +113,7 @@
    },
    "outputs": [],
    "source": [
-    "top_ten_langs = head_files.distinct()\\\n",
+    "top_ten_langs = head_blobs.distinct()\\\n",
     ".groupBy(\"lang\").agg(count(\"*\").alias(\"count\"))\\\n",
     ".orderBy(\"count\").sort(desc(\"count\")).limit(10)\\\n",
     ".show()"
@@ -125,7 +125,7 @@
     "collapsed": true
    },
    "source": [
-    "### Get all Java files"
+    "### Get all Java blobs"
    ]
   },
   {
@@ -136,7 +136,7 @@
    },
    "outputs": [],
    "source": [
-    " head_files.groupBy(\"lang\").agg(count(\"*\").alias(\"count\")).filter(\"lang='Java'\").show()"
+    " head_blobs.groupBy(\"lang\").agg(count(\"*\").alias(\"count\")).filter(\"lang='Java'\").show()"
    ]
   },
   {
@@ -147,14 +147,14 @@
    },
    "outputs": [],
    "source": [
-    "head_files.limit(10).show()"
+    "head_blobs.limit(10).show()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Get identifiers of all Python files"
+    "### Get identifiers of all Python blobs"
    ]
   },
   {
@@ -167,7 +167,7 @@
    "source": [
     "idents = engine.repositories.filter(\"is_fork = false\").references\\\n",
     ".head_ref.commits.first_reference_commit\\\n",
-    ".files\\\n",
+    ".tree_entries.blobs\\\n",
     ".classify_languages()\\\n",
     ".extract_uasts()\\\n",
     ".query_uast('//*[@roleIdentifier and not(@roleIncomplete)]')\\\n",

--- a/python/sourced/engine/engine.py
+++ b/python/sourced/engine/engine.py
@@ -56,17 +56,17 @@ class Engine(object):
                                      self.session, self.__implicits)
 
 
-    def files(self, repository_ids=[], reference_names=[], commit_hashes=[]):
+    def blobs(self, repository_ids=[], reference_names=[], commit_hashes=[]):
         """
         Retrieves the files of a list of repositories, reference names and commit hashes.
         So the result will be a DataFrame of all the files in the given commits that are
         in the given references that belong to the given repositories.
 
-        >>> files_df = engine.files(repo_ids, ref_names, hashes)
+        >>> blobs_df = engine.blobs(repo_ids, ref_names, hashes)
 
         Calling this function with no arguments is the same as:
 
-        >>> engine.repositories.references.commits.files
+        >>> engine.repositories.references.commits.first_reference_commit.tree_entries.blobs
 
         :param repository_ids: list of repository ids to filter by (optional)
         :type repository_ids: list of strings
@@ -74,7 +74,7 @@ class Engine(object):
         :type reference_names: list of strings
         :param commit_hashes: list of hashes to filter by (optional)
         :type commit_hashes: list of strings
-        :rtype: FilesDataFrame
+        :rtype: BlobsDataFrame
         """
         if not isinstance(repository_ids, list):
             raise Exception("repository_ids must be a list")
@@ -85,7 +85,7 @@ class Engine(object):
         if not isinstance(commit_hashes, list):
             raise Exception("commit_hashes must be a list")
 
-        return FilesDataFrame(self.__engine.getFiles(repository_ids,
+        return BlobsDataFrame(self.__engine.getBlobs(repository_ids,
                                                   reference_names,
                                                   commit_hashes),
                               self.session,
@@ -226,6 +226,30 @@ class RepositoriesDataFrame(SourcedDataFrame):
                                    self._session, self._implicits)
 
 
+    @property
+    def head_ref(self):
+        """
+        Filters the current DataFrame references to only contain those rows whose reference is HEAD.
+
+        >>> heads_df = repos_df.head_ref
+
+        :rtype: ReferencesDataFrame
+        """
+        return self.references.ref('refs/heads/HEAD')
+
+
+    @property
+    def master_ref(self):
+        """
+        Filters the current DataFrame references to only contain those rows whose reference is master.
+
+        >>> master_df = repos_df.master_ref
+
+        :rtype: ReferencesDataFrame
+        """
+        return self.references.ref('refs/heads/master')
+
+
 class ReferencesDataFrame(SourcedDataFrame):
     """
     DataFrame with references.
@@ -305,15 +329,15 @@ class ReferencesDataFrame(SourcedDataFrame):
 
 
     @property
-    def files(self):
+    def blobs(self):
         """
-        Returns this DataFrame joined with the files DataSource.
+        Returns this DataFrame joined with the blobs DataSource.
 
-        >>> files_df = refs_df.files
+        >>> blobs_df = refs_df.blobs
 
-        :rtype: FilesDataFrame
+        :rtype: BlobsDataFrame
         """
-        return FilesDataFrame(self._engine_dataframe.getFiles(), self._session, self._implicits)
+        return BlobsDataFrame(self._engine_dataframe.getBlobs(), self._session, self._implicits)
 
 
 class CommitsDataFrame(SourcedDataFrame):
@@ -357,21 +381,65 @@ class CommitsDataFrame(SourcedDataFrame):
 
 
     @property
-    def files(self):
+    def tree_entries(self):
         """
-        Returns this DataFrame joined with the files DataSource.
+        Returns this DataFrame joined with the tree entries DataSource.
 
-        >>> files_df = commits_df.FilesDataFrame
+        >>> entries_df = commits_df.tree_entries
 
-        :rtype: FilesDataFrame
+        :rtype: TreeEntriesDataFrame
         """
-        return FilesDataFrame(self._engine_dataframe.getFiles(), self._session, self._implicits)
+        return TreeEntriesDataFrame(self._engine_dataframe.getTreeEntries(), self._session, self._implicits)
 
 
-class FilesDataFrame(SourcedDataFrame):
+    @property
+    def blobs(self):
+        """
+        Returns a new DataFrame with the blob associated to each tree entry of the commit.
+
+        >>> > blobs_df = commits_df.blobs
+
+        :rtype: BlobsDataFrame
+        """
+        return BlobsDataFrame(self._engine_dataframe.getBlobs(), self._session,
+                                self._implicits)
+
+
+class TreeEntriesDataFrame(SourcedDataFrame):
     """
-    DataFrame containing files data.
-    This class should not be instantiated directly, please get your FilesDataFrame using the
+    DataFrame with tree entries data data.
+    This class should not be instantiated directly, please get your TreeEntriesDataFrame using the
+    provided methods.
+
+    :param jdf: Java DataFrame
+    :type jdf: py4j.java_gateway.JavaObject
+    :param session: Spark Session to use
+    :type session: pyspark.sql.SparkSession
+    :param implicits: Implicits object from Scala
+    :type implicits: py4j.java_gateway.JavaObject
+    """
+
+    def __init__(self, jdf, session, implicits):
+        SourcedDataFrame.__init__(self, jdf, session, implicits)
+
+
+    @property
+    def blobs(self):
+        """
+        Returns a new DataFrame with the blob associated to each tree entry.
+
+        >>> > blobs_df = trees_df.blobs
+
+        :rtype: BlobsDataFrame
+        """
+        return BlobsDataFrame(self._engine_dataframe.getBlobs(), self._session,
+                              self._implicits)
+
+
+class BlobsDataFrame(SourcedDataFrame):
+    """
+    DataFrame containing blobs data.
+    This class should not be instantiated directly, please get your BlobsDataFrame using the
     provided methods.
 
     :param jdf: Java DataFrame
@@ -388,23 +456,23 @@ class FilesDataFrame(SourcedDataFrame):
 
     def classify_languages(self):
         """
-        Returns a new DataFrame with the language data of any file added to
+        Returns a new DataFrame with the language data of any blob added to
         its row.
 
-        >>> files_lang_df = files_df.classify_languages
+        >>> blobs_lang_df = blobs_df.classify_languages
 
-        :rtype: FilesWithLanguageDataFrame
+        :rtype: BlobsWithLanguageDataFrame
         """
-        return FilesWithLanguageDataFrame(self._engine_dataframe.classifyLanguages(),
+        return BlobsWithLanguageDataFrame(self._engine_dataframe.classifyLanguages(),
                                           self._session, self._implicits)
 
 
     def extract_uasts(self):
         """
-        Returns a new DataFrame with the parsed UAST data of any file added to
+        Returns a new DataFrame with the parsed UAST data of any blob added to
         its row.
 
-        >>> files_df.extract_uasts
+        >>> blobs_df.extract_uasts
 
         :rtype: UASTsDataFrame
         """
@@ -412,10 +480,10 @@ class FilesDataFrame(SourcedDataFrame):
                               self._session, self._implicits)
 
 
-class FilesWithLanguageDataFrame(SourcedDataFrame):
+class BlobsWithLanguageDataFrame(SourcedDataFrame):
     """
-    DataFrame containing files and language data.
-    This class should not be instantiated directly, please get your FilesWithLanguageDataFrame
+    DataFrame containing blobs and language data.
+    This class should not be instantiated directly, please get your BlobsWithLanguageDataFrame
     using the provided methods.
 
     :param jdf: Java DataFrame
@@ -432,10 +500,10 @@ class FilesWithLanguageDataFrame(SourcedDataFrame):
 
     def extract_uasts(self):
         """
-        Returns a new DataFrame with the parsed UAST data of any file added to
+        Returns a new DataFrame with the parsed UAST data of any blob added to
         its row.
 
-        >>> files_lang_df.extract_uasts
+        >>> blobs_lang_df.extract_uasts
 
         :rtype: UASTsDataFrame
         """

--- a/python/sourced/engine/engine.py
+++ b/python/sourced/engine/engine.py
@@ -58,8 +58,8 @@ class Engine(object):
 
     def blobs(self, repository_ids=[], reference_names=[], commit_hashes=[]):
         """
-        Retrieves the files of a list of repositories, reference names and commit hashes.
-        So the result will be a DataFrame of all the files in the given commits that are
+        Retrieves the blobs of a list of repositories, reference names and commit hashes.
+        So the result will be a DataFrame of all the blobs in the given commits that are
         in the given references that belong to the given repositories.
 
         >>> blobs_df = engine.blobs(repo_ids, ref_names, hashes)

--- a/python/sourced/examples/repo_files.py
+++ b/python/sourced/examples/repo_files.py
@@ -10,7 +10,7 @@ def main():
     session = SparkSession.builder.appName("test").master('local[*]').getOrCreate()
     engine = Engine(session, repos_path)
     rows = engine.repositories.references.head_ref.commits.first_reference_commit\
-        .files.select('path').collect()
+        .tree_entries.select('path').collect()
 
     files = [r['path'] for r in rows]
 

--- a/python/sourced/examples/uasts.py
+++ b/python/sourced/examples/uasts.py
@@ -9,7 +9,7 @@ def main():
     engine = Engine(session, repos_path)
     engine.repositories.references\
         .filter('name = "refs/heads/develop"')\
-        .commits.files\
+        .commits.first_reference_commit.tree_entries.blobs\
         .classify_languages()\
         .filter('lang = "Ruby"')\
         .extract_uasts()\

--- a/python/test/test_engine.py
+++ b/python/test/test_engine.py
@@ -1,5 +1,5 @@
 from sourced.engine import Engine
-from sourced.engine.engine import FilesDataFrame
+from sourced.engine.engine import BlobsDataFrame
 from .base import BaseTestCase
 from os import path
 import json
@@ -23,7 +23,7 @@ PYTHON_FILES = [
     ("hash1", False, "foo.py", bytearray("with open('somefile.txt') as f: contents=f.read()",'utf8'))
 ]
 
-FILE_COLUMNS = ["file_hash", "is_binary", "path", "content"]
+FILE_COLUMNS = ["blob_id", "is_binary", "path", "content"]
 
 
 class EngineTestCase(BaseTestCase):
@@ -101,47 +101,48 @@ class EngineTestCase(BaseTestCase):
             self.assertEqual(repo['count'], repos[repo["repository_id"]])
 
 
-    def test_files(self):
-        df = self.engine.repositories.references.commits.files
+    def test_tree_entries(self):
+        df = self.engine.repositories.references.commits.tree_entries
+        self.assertEqual(df.count(), 304362)
+        entry = df.sort(df.blob).limit(1).first()
+        self.assertEqual(entry.blob, '0020a823b6e5b06c9adb7def76ccd7ed098a06b8')
+        self.assertEqual(entry.path, 'spec/database_spec.rb')
+
+
+    def test_blobs(self):
+        df = self.engine.repositories.references.commits\
+            .tree_entries.blobs.drop("repository_id", "reference_name").distinct()
         self.assertEqual(df.count(), 91944)
-        file = df.sort(df.file_hash).limit(1).first()
-        self.assertEqual(file.file_hash, "0020a823b6e5b06c9adb7def76ccd7ed098a06b8")
+        file = df.sort(df.blob_id).limit(1).first()
+        self.assertEqual(file.blob_id, "0020a823b6e5b06c9adb7def76ccd7ed098a06b8")
         self.assertEqual(file.path, 'spec/database_spec.rb')
 
 
-    def test_files_from_refs(self):
-        df = self.engine.repositories.references.files
-        self.assertEqual(df.count(), 3512)
-        file = df.sort(df.file_hash).limit(1).first()
-        self.assertEqual(file.file_hash, "0024974e4b56afc8dea0d20e4ca90c1fa4323ce5")
-        self.assertEqual(file.path, 'sequel_core/stress/mem_array_keys.rb')
-
-
     def test_classify_languages(self):
-        df = self.engine.repositories.references.commits.files
-        row = df.sort(df.file_hash).limit(1).classify_languages().first()
-        self.assertEqual(row.file_hash, "0020a823b6e5b06c9adb7def76ccd7ed098a06b8")
+        df = self.engine.repositories.references.commits.tree_entries.blobs
+        row = df.sort(df.blob_id).limit(1).classify_languages().first()
+        self.assertEqual(row.blob_id, "0020a823b6e5b06c9adb7def76ccd7ed098a06b8")
         self.assertEqual(row.path, 'spec/database_spec.rb')
         self.assertEqual(row.lang, "Ruby")
 
 
     def test_extract_uasts(self):
-        df = self.engine.repositories.references.commits.files
-        row = df.sort(df.file_hash).limit(1).classify_languages()\
+        df = self.engine.repositories.references.commits.tree_entries.blobs
+        row = df.sort(df.blob_id).limit(1).classify_languages()\
             .extract_uasts().first()
-        self.assertEqual(row.file_hash, "0020a823b6e5b06c9adb7def76ccd7ed098a06b8")
+        self.assertEqual(row.blob_id, "0020a823b6e5b06c9adb7def76ccd7ed098a06b8")
         self.assertEqual(row.path, 'spec/database_spec.rb')
         self.assertEqual(row.lang, "Ruby")
         self.assertEqual(row.uast, [])
 
-        df = self.engine.repositories.references.commits.files
-        row = df.sort(df.file_hash).limit(1).extract_uasts().first()
-        self.assertEqual(row.file_hash, "0020a823b6e5b06c9adb7def76ccd7ed098a06b8")
+        df = self.engine.repositories.references.commits.tree_entries.blobs
+        row = df.sort(df.blob_id).limit(1).extract_uasts().first()
+        self.assertEqual(row.blob_id, "0020a823b6e5b06c9adb7def76ccd7ed098a06b8")
         self.assertEqual(row.path, 'spec/database_spec.rb')
         self.assertEqual(row.uast, [])
 
 
-    def test_engine_files(self):
+    def test_engine_blobs(self):
         rows = self.engine.repositories.references.head_ref.commits.sort('hash').limit(10).collect()
         repos = []
         hashes = []
@@ -149,28 +150,33 @@ class EngineTestCase(BaseTestCase):
             repos.append(row['repository_id'])
             hashes.append(row['hash'])
 
-        self.assertEqual(self.engine.files(repos, ["refs/heads/HEAD"], hashes).count(), 655)
+        df = self.engine.blobs(repos, ["refs/heads/HEAD"], hashes)\
+            .drop("repository_id", "reference_name").distinct()
+        self.assertEqual(df.count(), 655)
 
 
-    def test_engine_files_repository(self):
-        files = self.engine.files(repository_ids=['github.com/xiyou-linuxer/faq-xiyoulinux'])
-        self.assertEqual(files.count(), 2421)
+    def test_engine_blobs_repository(self):
+        blobs = self.engine.blobs(repository_ids=['github.com/xiyou-linuxer/faq-xiyoulinux'])\
+            .drop("repository_id", "reference_name").distinct()
+        self.assertEqual(blobs.count(), 2421)
 
 
-    def test_engine_files_reference(self):
-        files = self.engine.files(reference_names=['refs/heads/develop'])
-        self.assertEqual(files.count(), 425)
+    def test_engine_blobs_reference(self):
+        blobs = self.engine.blobs(reference_names=['refs/heads/develop'])\
+            .drop("repository_id", "reference_name").distinct()
+        self.assertEqual(blobs.count(), 425)
 
 
-    def test_engine_files_hash(self):
-        files = self.engine.files(commit_hashes=['fff7062de8474d10a67d417ccea87ba6f58ca81d'])
-        self.assertEqual(files.count(), 2)
+    def test_engine_blobs_hash(self):
+        blobs = self.engine.blobs(commit_hashes=['fff7062de8474d10a67d417ccea87ba6f58ca81d'])\
+            .drop("repository_id", "reference_name").distinct()
+        self.assertEqual(blobs.count(), 2)
 
 
     def test_uast_query(self):
         df = self.session.createDataFrame(PYTHON_FILES, FILE_COLUMNS)
         repos = self.engine.repositories
-        df = FilesDataFrame(df._jdf, repos._session, repos._implicits)
+        df = BlobsDataFrame(df._jdf, repos._session, repos._implicits)
         rows = df.extract_uasts().query_uast('//*[@roleIdentifier and not(@roleIncomplete)]').collect()
         self.assertEqual(len(rows), 1)
 
@@ -186,7 +192,7 @@ class EngineTestCase(BaseTestCase):
     def test_uast_query_cols(self):
         df = self.session.createDataFrame(PYTHON_FILES, FILE_COLUMNS)
         repos = self.engine.repositories
-        df = FilesDataFrame(df._jdf, repos._session, repos._implicits)
+        df = BlobsDataFrame(df._jdf, repos._session, repos._implicits)
         rows = df.extract_uasts()\
             .query_uast('//*[@roleIdentifier]')\
             .query_uast('/*[not(@roleIncomplete)]', 'result', 'result2')\
@@ -205,7 +211,7 @@ class EngineTestCase(BaseTestCase):
     def test_extract_tokens(self):
         df = self.session.createDataFrame(PYTHON_FILES, FILE_COLUMNS)
         repos = self.engine.repositories
-        df = FilesDataFrame(df._jdf, repos._session, repos._implicits)
+        df = BlobsDataFrame(df._jdf, repos._session, repos._implicits)
         row = df.extract_uasts().query_uast('//*[@roleIdentifier and not(@roleIncomplete)]')\
             .extract_tokens().first()
 

--- a/src/main/scala/tech/sourced/engine/GitOptimizer.scala
+++ b/src/main/scala/tech/sourced/engine/GitOptimizer.scala
@@ -28,7 +28,7 @@ object SquashGitRelationJoin extends Rule[LogicalPlan] {
 
       jd match {
         case JoinData(filters, joinConditions, projectExprs, attributes, Some(session), _) =>
-          val relation = LogicalRelation(
+          var relation = LogicalRelation(
             GitRelation(
               session,
               GitOptimizer.attributesToSchema(attributes), joinConditions
@@ -37,8 +37,13 @@ object SquashGitRelationJoin extends Rule[LogicalPlan] {
             None
           )
 
-          val node = filters match {
-            case Some(filter) => Filter(filter, relation)
+          var node = GitOptimizer.joinConditionsToFilters(joinConditions) match {
+            case Some(condition) => Filter(condition, relation)
+            case None => relation
+          }
+
+          node = filters match {
+            case Some(filter) => Filter(filter, node)
             case None => relation
           }
 
@@ -254,4 +259,56 @@ object GitOptimizer extends Logging {
         .map((a: Attribute) => StructField(a.name, a.dataType, a.nullable, a.metadata))
         .toArray
     )
+
+  /**
+    * Takes the join conditions, if any, and transforms them to filters, by removing some filters
+    * that don't make sense because they are already done inside the iterator.
+    *
+    * @param expr optional condition to transform
+    * @return transformed join conditions or none
+    */
+  def joinConditionsToFilters(expr: Option[Expression]): Option[Expression] = expr match {
+    case Some(e) =>
+      e transformUp {
+        case Equality(
+        a: AttributeReference,
+        b: AttributeReference
+        ) if isRedundantAttributeFilter(a, b) =>
+          EqualTo(Literal(1), Literal(1))
+
+        case BinaryOperator(a, Equality(IntegerLiteral(1), IntegerLiteral(1))) =>
+          a
+
+        case BinaryOperator(Equality(IntegerLiteral(1), IntegerLiteral(1)), b) =>
+          b
+      } match {
+        case Equality(IntegerLiteral(1), IntegerLiteral(1)) =>
+          None
+        case finalExpr =>
+          Some(finalExpr)
+      }
+    case None => None
+  }
+
+  /**
+    * Returns whether the equality between the two given attribute references is redundant
+    * for a filter (because they are taken care of inside the iterators).
+    *
+    * @param a left attribute
+    * @param b right attribute
+    * @return is redundant or not
+    */
+  def isRedundantAttributeFilter(a: AttributeReference, b: AttributeReference): Boolean = {
+    val orderedNames = Seq(a.name, b.name).sorted
+    (orderedNames.head, orderedNames(1)) match {
+      case ("id", "repository_id") => true
+      case ("repository_id", "repository_id") => true
+      case ("name", "reference_name") => true
+      case ("commit_hash", "hash") => true
+      case ("commit_hash", "commit_hash") => true
+      case ("blob", "blob_id") => true
+      case _ => false
+    }
+  }
+
 }

--- a/src/main/scala/tech/sourced/engine/Schema.scala
+++ b/src/main/scala/tech/sourced/engine/Schema.scala
@@ -39,8 +39,6 @@ private[engine] object Schema {
       StructField("hash", StringType, nullable = false) ::
       StructField("message", StringType, nullable = false) ::
       StructField("parents", ArrayType(StringType, containsNull = false)) ::
-      StructField("tree", MapType(StringType, StringType, valueContainsNull = false)) ::
-      StructField("blobs", ArrayType(StringType, containsNull = false)) ::
       StructField("parents_count", IntegerType, nullable = false) ::
 
       StructField("author_email", StringType) ::
@@ -55,15 +53,27 @@ private[engine] object Schema {
   )
 
   /**
-    * Files table schema containing all the files data.
+    * Tree Entries table schema containing all the tree entries data.
     */
-  val files = StructType(
-    StructField("file_hash", StringType, nullable = false) ::
-      StructField("content", BinaryType) ::
-      StructField("commit_hash", StringType, nullable = false) ::
-      StructField("is_binary", BooleanType, nullable = false) ::
-      StructField("path", StringType) ::
+  val treeEntries = StructType(
+    StructField("commit_hash", StringType, nullable = false) ::
+      StructField("repository_id", StringType, nullable = false) ::
+      StructField("reference_name", StringType, nullable = false) ::
+      StructField("path", StringType, nullable = false) ::
+      StructField("blob", StringType, nullable = false) ::
+      Nil
+  )
 
+  /**
+    * Blobs table schema containing all the blobs data.
+    */
+  val blobs = StructType(
+    StructField("blob_id", StringType, nullable = false) ::
+      StructField("commit_hash", StringType, nullable = false) ::
+      StructField("repository_id", StringType, nullable = false) ::
+      StructField("reference_name", StringType, nullable = false) ::
+      StructField("content", BinaryType) ::
+      StructField("is_binary", BooleanType, nullable = false) ::
       Nil
   )
 

--- a/src/main/scala/tech/sourced/engine/iterator/BlobIterator.scala
+++ b/src/main/scala/tech/sourced/engine/iterator/BlobIterator.scala
@@ -3,14 +3,12 @@ package tech.sourced.engine.iterator
 import org.apache.spark.internal.Logging
 import org.eclipse.jgit.diff.RawText
 import org.eclipse.jgit.lib.{ObjectId, ObjectReader, Repository}
-import org.eclipse.jgit.treewalk.TreeWalk
-import org.slf4j.Logger
 import tech.sourced.engine.util.CompiledFilter
 
 import scala.collection.mutable
 
 /**
-  * Iterator that will return rows of files in a repository.
+  * Iterator that will return rows of blobs in a repository.
   *
   * @param finalColumns final columns that must be in the resultant row
   * @param repo         repository to get the data from
@@ -19,76 +17,74 @@ import scala.collection.mutable
   */
 class BlobIterator(finalColumns: Array[String],
                    repo: Repository,
-                   prevIter: CommitIterator,
+                   prevIter: TreeEntryIterator,
                    filters: Seq[CompiledFilter])
-  extends RootedRepoIterator[CommitTree](finalColumns, repo, prevIter, filters) with Logging {
+  extends RootedRepoIterator[Blob](finalColumns, repo, prevIter, filters) with Logging {
 
+  // stores the references to the blob, so we only have to read the blob once
+  val blobCache: mutable.HashMap[ObjectId, Array[Byte]] = mutable.HashMap()
 
-  private val computed = mutable.HashSet[String]()
-
-  /** @inheritdoc */
-  override protected def loadIterator(filters: Seq[CompiledFilter]): Iterator[CommitTree] = {
-    val commitIter = Option(prevIter) match {
+  /** @inheritdoc*/
+  override protected def loadIterator(filters: Seq[CompiledFilter]): Iterator[Blob] = {
+    val treeEntryIter = Option(prevIter) match {
       case Some(it) =>
-        val commitId = it.currentRow.commit.getId.getName
-        if (computed.contains(commitId)) {
-          return Seq().toIterator
-        }
-
-        computed.add(commitId)
         Seq(it.currentRow).toIterator
-      case None => CommitIterator.loadIterator(repo, None, filters.flatMap(_.matchingCases))
+      case None => TreeEntryIterator.loadIterator(
+        repo,
+        None,
+        filters.flatMap(_.matchingCases),
+        blobIdKey = "blob_id"
+      )
     }
 
-    commitIter.flatMap(c => {
-      val commitId = c.commit.getId
-      if (repo.hasObject(commitId)) {
-        JGitBlobIterator(getCommitTree(commitId), log)
+    val blobIds = filters.flatMap(_.matchingCases).flatMap {
+      case ("blob_id", ids) => ids.map(i => ObjectId.fromString(i.toString))
+      case _ => Seq()
+    }
+
+    val iter = treeEntryIter.flatMap(entry => {
+      if (repo.hasObject(entry.blob)) {
+        Some(Blob(entry.blob, entry.commitHash, entry.ref, entry.repo))
       } else {
-        Seq()
+        None
       }
     })
+
+    if (blobIds.nonEmpty) {
+      iter.filter(b => blobIds.contains(b.id))
+    } else {
+      iter
+    }
   }
 
-  /** @inheritdoc */
-  override protected def mapColumns(commitTree: CommitTree): Map[String, () => Any] = {
-    val content = BlobIterator.readFile(
-      commitTree.tree.getObjectId(0),
-      commitTree.tree.getObjectReader
-    )
+  /** @inheritdoc*/
+  override protected def mapColumns(blob: Blob): Map[String, () => Any] = {
+    // Don't read the blob again if it's already in the blob cache
+    val content = if (blobCache.contains(blob.id)) {
+      blobCache.getOrElse(blob.id, Array.emptyByteArray)
+    } else {
+      val c = BlobIterator.readFile(
+        blob.id,
+        repo.newObjectReader()
+      )
+      blobCache.put(blob.id, c)
+      c
+    }
     val isBinary = RawText.isBinary(content)
-    Map[String, () => Any](
-      "file_hash" -> (() => commitTree.tree.getObjectId(0).name),
-      "content" -> (() => if (isBinary) Array.emptyByteArray else content),
-      "commit_hash" -> (() => commitTree.commit.name),
-      "is_binary" -> (() => isBinary),
-      "path" -> (() => commitTree.tree.getPathString)
-    )
-  }
 
-  /**
-    * Returns the commit and its tree for the given commit ID.
-    *
-    * @param commitId commit ID
-    * @return commit with tree
-    */
-  private def getCommitTree(commitId: ObjectId) = {
-    val revCommit = repo.parseCommit(commitId)
-    val treeWalk = new TreeWalk(repo)
-    treeWalk.setRecursive(true)
-    treeWalk.addTree(revCommit.getTree)
-    CommitTree(commitId, treeWalk)
+    Map[String, () => Any](
+      "commit_hash" -> (() => blob.commit.getName),
+      "repository_id" -> (() => blob.repo),
+      "reference_name" -> (() => blob.ref),
+      "blob_id" -> (() => blob.id.getName),
+      "content" -> (() => if (isBinary) Array.emptyByteArray else content),
+      "is_binary" -> (() => isBinary)
+    )
   }
 
 }
 
-/**
-  * Contains a commit and its tree.
-  *
-  * @param commit ObjectId of the commit
-  * @param tree   the tree
-  */
-case class CommitTree(commit: ObjectId, tree: TreeWalk)
+case class Blob(id: ObjectId, commit: ObjectId, ref: String, repo: String)
 
 object BlobIterator {
   /** Max bytes to read for the content of a file. */
@@ -116,79 +112,4 @@ object BlobIterator {
     reader.close()
     data
   }
-}
-
-/**
-  * Iterates a Tree from a given commit, skipping missing blobs.
-  * Must not produce un-reachable objects, as client has no way of dealing with it.
-  *
-  * @see [[BlobIterator#mapColumns]]
-  */
-class JGitBlobIterator[T <: CommitTree](commitTree: T, log: Logger) extends Iterator[T] {
-  var wasAlreadyMoved = false
-
-  /** @inheritdoc */
-  override def hasNext: Boolean = {
-    if (wasAlreadyMoved) {
-      return true
-    }
-    val hasNext = try {
-      moveIteratorSkippingMissingObj
-    } catch {
-      case e: Exception =>
-        log.error(s"Failed to iterate tree - due to ${e.getClass.getSimpleName}", e)
-        false
-    }
-    wasAlreadyMoved = true
-    if (!hasNext) {
-      commitTree.tree.close()
-    }
-    hasNext
-  }
-
-  /** @inheritdoc */
-  override def next(): T = {
-    if (!wasAlreadyMoved) {
-      moveIteratorSkippingMissingObj
-    }
-    wasAlreadyMoved = false
-    commitTree
-  }
-
-  /**
-    * Moves the iterator but skips non-existing objects.
-    *
-    * @return whether it contains more rows or not
-    */
-  private def moveIteratorSkippingMissingObj: Boolean = {
-    val hasNext = commitTree.tree.next()
-    if (!hasNext) {
-      return false
-    }
-
-    if (commitTree.tree.getObjectReader.has(commitTree.tree.getObjectId(0))) {
-      true
-    } else { // tree hasNext, but blob obj is missing
-      log.debug(s"Skip non-existing ${commitTree.tree.getObjectId(0).name()} ")
-      moveIteratorSkippingMissingObj
-    }
-  }
-
-}
-
-object JGitBlobIterator {
-  /**
-    * Creates a new JGitBlobIterator from a commit tree and a logger.
-    *
-    * @constructor
-    * @param commitTree commit tree
-    * @param log        logger
-    * @return a JGit blob iterator
-    */
-  def apply(commitTree: CommitTree, log: Logger): JGitBlobIterator[CommitTree] =
-    new JGitBlobIterator(
-      commitTree,
-      log
-    )
-
 }

--- a/src/main/scala/tech/sourced/engine/iterator/CommitIterator.scala
+++ b/src/main/scala/tech/sourced/engine/iterator/CommitIterator.scala
@@ -25,7 +25,7 @@ class CommitIterator(finalColumns: Array[String],
                      filters: Seq[CompiledFilter])
   extends RootedRepoIterator[ReferenceWithCommit](finalColumns, repo, prevIter, filters) {
 
-  /** @inheritdoc*/
+  /** @inheritdoc */
   override protected def loadIterator(filters: Seq[CompiledFilter]): Iterator[ReferenceWithCommit] =
     CommitIterator.loadIterator(
       repo,
@@ -36,13 +36,11 @@ class CommitIterator(finalColumns: Array[String],
       filters.flatMap(_.matchingCases)
     )
 
-  /** @inheritdoc */
+  /** @inheritdoc*/
   override protected def mapColumns(obj: ReferenceWithCommit): Map[String, () => Any] = {
     val (repoId, refName) = RootedRepo.parseRef(repo, obj.ref.getName)
 
     val c: RevCommit = obj.commit
-    lazy val files: Map[String, String] = this.getFiles(obj.commit)
-
     Map[String, () => Any](
       "repository_id" -> (() => repoId),
       "reference_name" -> (() => refName),
@@ -50,8 +48,6 @@ class CommitIterator(finalColumns: Array[String],
       "hash" -> (() => ObjectId.toString(c.getId)),
       "message" -> (() => c.getFullMessage),
       "parents" -> (() => c.getParents.map(p => ObjectId.toString(p.getId))),
-      "tree" -> (() => files),
-      "blobs" -> (() => files.values.toArray),
       "parents_count" -> (() => c.getParentCount),
 
       "author_email" -> (() => c.getAuthorIdent.getEmailAddress),
@@ -64,27 +60,6 @@ class CommitIterator(finalColumns: Array[String],
     )
   }
 
-  /**
-    * Retrieves the files for a commit.
-    *
-    * @param c commit
-    * @return map of files
-    */
-  private def getFiles(c: RevCommit): Map[String, String] = {
-    val treeWalk: TreeWalk = new TreeWalk(repo)
-    val nth: Int = treeWalk.addTree(c.getTree.getId)
-    treeWalk.setRecursive(false)
-
-    Stream.continually(treeWalk)
-      .takeWhile(_.next()).map(tree => {
-      if (tree.isSubtree) {
-        tree.enterSubtree()
-      }
-      tree
-    }).filter(!_.isSubtree)
-      .map(
-        walker => new String(walker.getRawPath) -> ObjectId.toString(walker.getObjectId(nth))).toMap
-  }
 }
 
 case class ReferenceWithCommit(ref: Ref, commit: RevCommit, index: Int)
@@ -132,6 +107,7 @@ object CommitIterator {
 
     val hashes = filters.flatMap {
       case (k, h) if k == hashKey => h.map(_.toString)
+      case ("hash", h) => h.map(_.toString)
       case _ => Seq()
     }
 
@@ -162,7 +138,7 @@ class RefWithCommitIterator(repo: Repository,
   private var commits: Iterator[RevCommit] = _
   private var index: Int = 0
 
-  /** @inheritdoc */
+  /** @inheritdoc*/
   override def hasNext: Boolean = {
     while ((commits == null || !commits.hasNext) && refs.hasNext) {
       actualRef = refs.next()
@@ -181,7 +157,7 @@ class RefWithCommitIterator(repo: Repository,
     refs.hasNext || (commits != null && commits.hasNext)
   }
 
-  /** @inheritdoc */
+  /** @inheritdoc*/
   override def next(): ReferenceWithCommit = {
     val result: ReferenceWithCommit = ReferenceWithCommit(actualRef, commits.next(), index)
     index += 1

--- a/src/main/scala/tech/sourced/engine/iterator/CommitIterator.scala
+++ b/src/main/scala/tech/sourced/engine/iterator/CommitIterator.scala
@@ -29,10 +29,7 @@ class CommitIterator(finalColumns: Array[String],
   override protected def loadIterator(filters: Seq[CompiledFilter]): Iterator[ReferenceWithCommit] =
     CommitIterator.loadIterator(
       repo,
-      Option(prevIter) match {
-        case Some(it) => Option(it.currentRow)
-        case None => None
-      },
+      Option(prevIter).map(_.currentRow),
       filters.flatMap(_.matchingCases)
     )
 

--- a/src/main/scala/tech/sourced/engine/iterator/ReferenceIterator.scala
+++ b/src/main/scala/tech/sourced/engine/iterator/ReferenceIterator.scala
@@ -19,7 +19,7 @@ class ReferenceIterator(finalColumns: Array[String],
                         filters: Seq[CompiledFilter])
   extends RootedRepoIterator[Ref](finalColumns, repo, prevIter, filters) {
 
-  /** @inheritdoc*/
+  /** @inheritdoc */
   protected def loadIterator(filters: Seq[CompiledFilter]): Iterator[Ref] =
     ReferenceIterator.loadIterator(
       repo,
@@ -30,7 +30,7 @@ class ReferenceIterator(finalColumns: Array[String],
       filters.flatMap(_.matchingCases)
     )
 
-  /** @inheritdoc*/
+  /** @inheritdoc */
   override protected def mapColumns(ref: Ref): Map[String, () => Any] = {
     val (repoId, refName) = RootedRepo.parseRef(repo, ref.getName)
     Map[String, () => Any](
@@ -68,6 +68,7 @@ object ReferenceIterator {
                    refNameKey: String = "name"): Iterator[Ref] = {
     val referenceNames = filters.flatMap {
       case (k, refNames) if k == refNameKey => refNames.map(_.toString)
+      case ("name", refNames) => refNames.map(_.toString)
       case _ => Seq()
     }
 
@@ -80,7 +81,7 @@ object ReferenceIterator {
 
         if (filterRepos.isEmpty || filterRepos.contains(id)) Array(id) else Array()
       case None =>
-        RepositoryIterator.loadIterator(repo, filters, "repository_id").toArray
+        RepositoryIterator.loadIterator(repo, filters, repoKey).toArray
     }
 
     val out = repo.getAllRefs.asScala.values.filter(ref => {

--- a/src/main/scala/tech/sourced/engine/iterator/ReferenceIterator.scala
+++ b/src/main/scala/tech/sourced/engine/iterator/ReferenceIterator.scala
@@ -23,10 +23,7 @@ class ReferenceIterator(finalColumns: Array[String],
   protected def loadIterator(filters: Seq[CompiledFilter]): Iterator[Ref] =
     ReferenceIterator.loadIterator(
       repo,
-      Option(prevIter) match {
-        case Some(it) => Option(it.currentRow)
-        case None => None
-      },
+      Option(prevIter).map(_.currentRow),
       filters.flatMap(_.matchingCases)
     )
 

--- a/src/main/scala/tech/sourced/engine/iterator/RepositoryIterator.scala
+++ b/src/main/scala/tech/sourced/engine/iterator/RepositoryIterator.scala
@@ -60,6 +60,7 @@ object RepositoryIterator {
                    repoKey: String = "id"): Iterator[String] = {
     val ids = filters.flatMap {
       case (k, repoIds) if k == repoKey => repoIds.map(_.toString)
+      case ("id", repoIds) => repoIds.map(_.toString)
       case _ => Seq()
     }
 

--- a/src/main/scala/tech/sourced/engine/iterator/RootedRepoIterator.scala
+++ b/src/main/scala/tech/sourced/engine/iterator/RootedRepoIterator.scala
@@ -63,10 +63,6 @@ abstract class RootedRepoIterator[T](finalColumns: Array[String],
     */
   protected def mapColumns(obj: T): RawRow
 
-  private val repoConfig = repo.getConfig
-
-  private val remotes = repoConfig.getSubsections("remote").asScala
-
   //final private def isEmpty: Boolean = !hasNext
 
   /**

--- a/src/main/scala/tech/sourced/engine/iterator/TreeEntryIterator.scala
+++ b/src/main/scala/tech/sourced/engine/iterator/TreeEntryIterator.scala
@@ -1,0 +1,140 @@
+package tech.sourced.engine.iterator
+
+import org.eclipse.jgit.lib.{ObjectId, Repository}
+import org.eclipse.jgit.treewalk.TreeWalk
+import tech.sourced.engine.util.{CompiledFilter, Filter}
+
+/**
+  * Iterator that will return rows of commits in a repository.
+  *
+  * @param finalColumns final columns that must be in the resultant row
+  * @param repo         repository to get the data from
+  * @param prevIter     previous iterator, if the iterator is chained
+  * @param filters      filters for the iterator
+  */
+class TreeEntryIterator(finalColumns: Array[String],
+                        repo: Repository,
+                        prevIter: CommitIterator,
+                        filters: Seq[CompiledFilter])
+  extends RootedRepoIterator[TreeEntry](finalColumns, repo, prevIter, filters) {
+
+  /** @inheritdoc*/
+  override protected def loadIterator(filters: Seq[CompiledFilter]): Iterator[TreeEntry] =
+    TreeEntryIterator.loadIterator(
+      repo,
+      Option(prevIter) match {
+        case Some(it) => Option(it.currentRow)
+        case None => None
+      },
+      filters.flatMap(_.matchingCases)
+    )
+
+  /** @inheritdoc */
+  override protected def mapColumns(obj: TreeEntry): Map[String, () => Any] = {
+    Map[String, () => Any](
+      "commit_hash" -> (() => obj.commitHash.getName),
+      "reference_name" -> (() => obj.ref),
+      "repository_id" -> (() => obj.repo),
+      "path" -> (() => obj.path),
+      "blob" -> (() => obj.blob.getName)
+    )
+  }
+
+}
+
+case class TreeEntry(commitHash: ObjectId, path: String, blob: ObjectId, ref: String, repo: String)
+
+object TreeEntryIterator {
+
+  /**
+    * Returns an iterator of references with commit.
+    *
+    * @param repo      repository to get the data from
+    * @param commit    the commit to get the entries from, if any
+    * @param filters   filters to skip some rows. "hash" and "index" fields are supported
+    *                  at iterator level. That means, any "hash" filter passed to this iterator
+    *                  will make it only retrieve commits with the given hashes. Same for "index".
+    * @param blobIdKey key of the blob ids
+    * @return the iterator
+    */
+  def loadIterator(repo: Repository,
+                   commit: Option[ReferenceWithCommit],
+                   filters: Seq[Filter.Match],
+                   blobIdKey: String = "blob"): Iterator[TreeEntry] = {
+    val commits = commit match {
+      case Some(c) =>
+        val filterCommits = filters.flatMap {
+          case ("commit_hash", cs) => cs.map(_.toString)
+          case _ => Seq()
+        }
+
+        if (filterCommits.isEmpty || filterCommits.contains(c.commit.getId.getName)) {
+          Seq(c).toIterator
+        } else {
+          Seq().toIterator
+        }
+      case None => CommitIterator.loadIterator(
+        repo,
+        None,
+        filters,
+        hashKey = "commit_hash"
+      )
+    }
+
+    val paths = filters.flatMap {
+      case ("path", p) => p.map(_.toString)
+      case _ => Seq()
+    }
+
+    val blobs = filters.flatMap {
+      case (k, ids) if k == blobIdKey => ids.map(id => ObjectId.fromString(id.toString))
+      case ("blob", ids) => ids.map(id => ObjectId.fromString(id.toString))
+      case _ => Seq()
+    }
+
+    var iter: Iterator[TreeEntry] = commits.flatMap(c => getTreeEntries(repo, c))
+    if (paths.nonEmpty) {
+      iter = iter.filter(te => paths.contains(te.path))
+    }
+
+    if (blobs.nonEmpty) {
+      iter = iter.filter(te => blobs.contains(te.blob))
+    }
+
+    iter
+  }
+
+  /**
+    * Retrieves the tree entries for a commit.
+    *
+    * @param repo Repository
+    * @param c    commit
+    * @return iterator of tree entries
+    */
+  private def getTreeEntries(repo: Repository, c: ReferenceWithCommit): Iterator[TreeEntry] = {
+    val treeWalk: TreeWalk = new TreeWalk(repo)
+    val nth: Int = treeWalk.addTree(c.commit.getTree.getId)
+    treeWalk.setRecursive(false)
+    val commitId = c.commit.getId
+    val (repoName, refName) = RootedRepo.parseRef(repo, c.ref.getName)
+
+    Stream.continually(treeWalk)
+      .takeWhile(_.next())
+      .map(tree => {
+        if (tree.isSubtree) {
+          tree.enterSubtree()
+        }
+        tree
+      })
+      .filter(!_.isSubtree)
+      .map(tree => TreeEntry(
+        commitId,
+        new String(tree.getRawPath),
+        tree.getObjectId(nth),
+        refName,
+        repoName
+      ))
+      .toIterator
+  }
+
+}

--- a/src/main/scala/tech/sourced/engine/iterator/TreeEntryIterator.scala
+++ b/src/main/scala/tech/sourced/engine/iterator/TreeEntryIterator.scala
@@ -22,10 +22,7 @@ class TreeEntryIterator(finalColumns: Array[String],
   override protected def loadIterator(filters: Seq[CompiledFilter]): Iterator[TreeEntry] =
     TreeEntryIterator.loadIterator(
       repo,
-      Option(prevIter) match {
-        case Some(it) => Option(it.currentRow)
-        case None => None
-      },
+      Option(prevIter).map(_.currentRow),
       filters.flatMap(_.matchingCases)
     )
 

--- a/src/main/scala/tech/sourced/engine/package.scala
+++ b/src/main/scala/tech/sourced/engine/package.scala
@@ -161,37 +161,42 @@ package object engine {
 
     /**
       * Returns a new [[org.apache.spark.sql.DataFrame]] with the product of joining the
-      * current dataframe with the files dataframe.
+      * current dataframe with the tree entries dataframe.
       *
       * {{{
-      * val filesDf = commitsDf.getFiles
+      * val entriesDf = commitsDf.getTreeEntries
       * }}}
       *
-      * It can also be used to directly retrieve the files of a references dataframe, but
-      * take into account that it will only get the first commit for that reference (that is,
-      * the latest state in which the reference is).
-      *
-      * {{{
-      * val filesDf = refsDf.getFiles
-      *
-      * // is equivalent to
-      *
-      * val filesDf = refsDf.getCommits.getFirstReferenceCommit.getFiles
-      * }}}
-      *
-      * @return new DataFrame containing also files data.
+      * @return new DataFrame containing also tree entries data.
       */
-    def getFiles: DataFrame = {
-      val filesDf = getDataSource("files", df.sparkSession)
+    def getTreeEntries: DataFrame = {
+      checkCols(df, "index", "hash") // references also has hash, index makes sure that is commits
+      val commitsDf = df.select("hash")
+      val entriesDf = getDataSource("tree_entries", df.sparkSession)
+      entriesDf.join(commitsDf, entriesDf("commit_hash") === commitsDf("hash"))
+        .drop($"hash")
+    }
 
-      if (df.schema.fieldNames.contains("index")) {
-        val commitsDf = df.select("hash")
-        filesDf.join(commitsDf, filesDf("commit_hash") === commitsDf("hash"))
-          .drop($"hash")
-          .distinct()
+    /**
+      * Returns a new [[org.apache.spark.sql.DataFrame]] with the product of joining the
+      * current dataframe with the blobs dataframe. If the current dataframe does not contain
+      * the tree entries data, getTreeEntries will be called automatically.
+      *
+      * {{{
+      * val blobsDf = treeEntriesDf.getBlobs
+      * val blobsDf2 = commitsDf.getBlobs // can be obtained from commits too
+      * }}}
+      *
+      * @return new DataFrame containing also blob data.
+      */
+    def getBlobs: DataFrame = {
+      if (!df.columns.contains("blob")) {
+        df.getTreeEntries.getBlobs
       } else {
-        checkCols(df, "name")
-        df.getCommits.getFirstReferenceCommit.getFiles
+        val treesDf = df.select("path", "blob")
+        val blobsDf = getDataSource("blobs", df.sparkSession)
+        blobsDf.join(treesDf, treesDf("blob") === blobsDf("blob_id"))
+          .drop($"blob")
       }
     }
 

--- a/src/test/scala/tech/sourced/engine/DefaultSourceSpec.scala
+++ b/src/test/scala/tech/sourced/engine/DefaultSourceSpec.scala
@@ -65,11 +65,11 @@ class DefaultSourceSpec extends FlatSpec with Matchers with BaseSivaSpec with Ba
 
 
     info("Files/blobs with commit hashes:\n")
-    val filesDf = references.getCommits.getBlobs.select(
+    val blobsDf = references.getCommits.getBlobs.select(
       "path", "commit_hash"
     )
-    filesDf.explain(true)
-    filesDf.show()
+    blobsDf.explain(true)
+    blobsDf.show()
 
     out should be(37)
   }
@@ -103,7 +103,7 @@ class DefaultSourceSpec extends FlatSpec with Matchers with BaseSivaSpec with Ba
     val spark = ss
     import spark.implicits._
 
-    val filesDf = engine
+    val blobsDf = engine
       .getRepositories.filter($"id" === "github.com/mawag/faq-xiyoulinux")
       .getReferences.getHEAD
       .getCommits.getBlobs
@@ -115,13 +115,13 @@ class DefaultSourceSpec extends FlatSpec with Matchers with BaseSivaSpec with Ba
         "is_binary"
       )
 
-    val cnt = filesDf.count()
+    val cnt = blobsDf.count()
     info(s"Total $cnt rows")
     cnt should be(2)
 
     info("UAST for files:\n")
-    val filesCols = filesDf.columns.length
-    val uasts = filesDf.classifyLanguages.extractUASTs()
+    val filesCols = blobsDf.columns.length
+    val uasts = blobsDf.classifyLanguages.extractUASTs()
 
     val uastsCols = uasts.columns.length
     assert(uastsCols - 2 == filesCols)

--- a/src/test/scala/tech/sourced/engine/DefaultSourceSpec.scala
+++ b/src/test/scala/tech/sourced/engine/DefaultSourceSpec.scala
@@ -74,26 +74,6 @@ class DefaultSourceSpec extends FlatSpec with Matchers with BaseSivaSpec with Ba
     out should be(37)
   }
 
-  it should "work with all storage levels" in {
-    import org.apache.spark.storage.StorageLevel._
-    val storageLevels = List(
-      DISK_ONLY,
-      DISK_ONLY_2,
-      MEMORY_AND_DISK,
-      MEMORY_AND_DISK_2,
-      MEMORY_AND_DISK_SER,
-      MEMORY_AND_DISK_SER_2,
-      MEMORY_ONLY,
-      MEMORY_ONLY_2,
-      MEMORY_ONLY_SER,
-      MEMORY_ONLY_SER_2,
-      NONE,
-      OFF_HEAP
-    )
-
-    storageLevels.foreach(engine.getRepositories.persist(_).count)
-  }
-
   it should "get all tree entries" in {
     val df = engine.getRepositories.getReferences.getCommits.getTreeEntries
     df.count() should be(304362)
@@ -171,7 +151,6 @@ class DefaultSourceSpec extends FlatSpec with Matchers with BaseSivaSpec with Ba
       .drop("repository_id", "reference_name")
       .distinct()
 
-    files.show(truncate = false)
     assert(files.count == 91944)
   }
 
@@ -183,7 +162,7 @@ class DefaultSourceSpec extends FlatSpec with Matchers with BaseSivaSpec with Ba
       .drop("repository_id", "reference_name")
       .distinct()
 
-    assert(files.count == 3512)
+    assert(files.count == 91944)
   }
 
   "Get files" should "return the correct files" in {

--- a/src/test/scala/tech/sourced/engine/DefaultSourceSpec.scala
+++ b/src/test/scala/tech/sourced/engine/DefaultSourceSpec.scala
@@ -74,6 +74,31 @@ class DefaultSourceSpec extends FlatSpec with Matchers with BaseSivaSpec with Ba
     out should be(37)
   }
 
+  it should "work with all storage levels" in {
+    import org.apache.spark.storage.StorageLevel._
+    val storageLevels = List(
+      DISK_ONLY,
+      DISK_ONLY_2,
+      MEMORY_AND_DISK,
+      MEMORY_AND_DISK_2,
+      MEMORY_AND_DISK_SER,
+      MEMORY_AND_DISK_SER_2,
+      MEMORY_ONLY,
+      MEMORY_ONLY_2,
+      MEMORY_ONLY_SER,
+      MEMORY_ONLY_SER_2,
+      NONE,
+      OFF_HEAP
+    )
+
+    storageLevels.foreach(engine.getRepositories.persist(_).count)
+  }
+
+  it should "get all tree entries" in {
+    val df = engine.getRepositories.getReferences.getCommits.getTreeEntries
+    df.count() should be(304362)
+  }
+
   "Convenience for getting files" should "work without reading commits" in {
     val spark = ss
     import spark.implicits._

--- a/src/test/scala/tech/sourced/engine/iterator/BlobIteratorSpec.scala
+++ b/src/test/scala/tech/sourced/engine/iterator/BlobIteratorSpec.scala
@@ -7,46 +7,51 @@ import tech.sourced.engine.util.{Attr, CompiledFilter, EqualFilter, InFilter}
 
 class BlobIteratorSpec extends FlatSpec with BaseRootedRepoIterator {
 
+  val columns = Array(
+    "blob_id",
+    "commit_hash",
+    "repository_id",
+    "reference_name",
+    "content",
+    "is_binary"
+  )
+
   "BlobIterator" should "return all blobs for files at every commit of all refs in repository" in {
     testIterator(
       new BlobIterator(
-        Array(
-          "file_hash",
-          "content",
-          "commit_hash",
-          "is_binary",
-          "path"
-        ), _, null, Seq()), {
+        columns, _, null, Seq()), {
         case (0, row) =>
           row.getString(0) should be("733c072369ca77331f392c40da7404c85c36542c")
-          new String(row.getAs[Array[Byte]](1), StandardCharsets.UTF_8)
+          row.getString(1) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
+          row.getString(2) should be("github.com/xiyou-linuxer/faq-xiyoulinux")
+          row.getString(3) should be("refs/heads/HEAD")
+          new String(row.getAs[Array[Byte]](4), StandardCharsets.UTF_8)
             .should(startWith("                    GNU GENERAL PUBLIC LICENSE"))
-          row.getString(2) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
-          row.getBoolean(3) should be(false)
-          row.getString(4) should be("LICENSE")
+          row.getBoolean(5) should be(false)
         case (1, row) =>
           row.getString(0) should be("2d2ad68c14c51e62595125b86b464427f6bf2126")
-          new String(row.getAs[Array[Byte]](1), StandardCharsets.UTF_8)
+          row.getString(1) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
+          row.getString(2) should be("github.com/xiyou-linuxer/faq-xiyoulinux")
+          row.getString(3) should be("refs/heads/HEAD")
+          new String(row.getAs[Array[Byte]](4), StandardCharsets.UTF_8)
             .should(startWith("# faq-xiyoulinux"))
-          row.getString(2) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
-          row.getBoolean(3) should be(false)
-          row.getString(4) should be("README.md")
+          row.getBoolean(5) should be(false)
         case (2, row) =>
           row.getString(0) should be("733c072369ca77331f392c40da7404c85c36542c")
-          new String(row.getAs[Array[Byte]](1), StandardCharsets.UTF_8)
+          row.getString(1) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
+          row.getString(2) should be("github.com/mawag/faq-xiyoulinux")
+          row.getString(3) should be("refs/heads/HEAD")
+          new String(row.getAs[Array[Byte]](4), StandardCharsets.UTF_8)
             .should(startWith("                    GNU GENERAL PUBLIC LICENSE"))
-          row.getString(2) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
-          row.getBoolean(3) should be(false)
-          row.getString(4) should be("LICENSE")
-
-        case (i, _) if i >= 22187 => fail("commits not expected")
+          row.getBoolean(5) should be(false)
         case _ =>
-      }, total = 22187, columnsCount = 5
+      }, total = 22187, columnsCount = columns.length
+      // NOTE: it differs from the number of tree entries in TreeEntryIteratorSpec because
+      // Blob Objects can be missing
     )
   }
 
-
-  "BlobIterator" should "filter refs and return only files in HEAD of the given ref" in {
+  it should "filter refs and return only blobs in HEAD of the given ref" in {
     val refFilters = Seq(EqualFilter(
       Attr("reference_name", "commits"),
       "refs/heads/HEAD")
@@ -54,208 +59,167 @@ class BlobIteratorSpec extends FlatSpec with BaseRootedRepoIterator {
 
     testIterator(
       new BlobIterator(
-        Array(
-          "file_hash",
-          "content",
-          "commit_hash",
-          "is_binary",
-          "path"
-        ), _, null, refFilters), {
+        columns, _, null, refFilters), {
         case (0, row) =>
           row.getString(0) should be("733c072369ca77331f392c40da7404c85c36542c")
-          new String(row.getAs[Array[Byte]](1), StandardCharsets.UTF_8)
+          row.getString(1) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
+          row.getString(2) should be("github.com/xiyou-linuxer/faq-xiyoulinux")
+          row.getString(3) should be("refs/heads/HEAD")
+          new String(row.getAs[Array[Byte]](4), StandardCharsets.UTF_8)
             .should(startWith("                    GNU GENERAL PUBLIC LICENSE"))
-          row.getString(2) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
-          row.getBoolean(3) should be(false)
-          row.getString(4) should be("LICENSE")
+          row.getBoolean(5) should be(false)
         case (1, row) =>
           row.getString(0) should be("2d2ad68c14c51e62595125b86b464427f6bf2126")
-          new String(row.getAs[Array[Byte]](1), StandardCharsets.UTF_8).
-            should(startWith("# faq-xiyoulinux"))
-          row.getString(2) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
-          row.getBoolean(3) should be(false)
-          row.getString(4) should be("README.md")
+          row.getString(1) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
+          row.getString(2) should be("github.com/xiyou-linuxer/faq-xiyoulinux")
+          row.getString(3) should be("refs/heads/HEAD")
+          new String(row.getAs[Array[Byte]](4), StandardCharsets.UTF_8)
+            .should(startWith("# faq-xiyoulinux"))
+          row.getBoolean(5) should be(false)
         case (2, row) =>
           row.getString(0) should be("733c072369ca77331f392c40da7404c85c36542c")
-          new String(row.getAs[Array[Byte]](1), StandardCharsets.UTF_8)
+          row.getString(1) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
+          row.getString(2) should be("github.com/mawag/faq-xiyoulinux")
+          row.getString(3) should be("refs/heads/HEAD")
+          new String(row.getAs[Array[Byte]](4), StandardCharsets.UTF_8)
             .should(startWith("                    GNU GENERAL PUBLIC LICENSE"))
-          row.getString(2) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
-          row.getBoolean(3) should be(false)
-          row.getString(4) should be("LICENSE")
-        case (3, row) =>
-          row.getString(0) should be("2d2ad68c14c51e62595125b86b464427f6bf2126")
-          new String(row.getAs[Array[Byte]](1), StandardCharsets.UTF_8)
-            .should(startWith("# faq-xiyoulinux"))
-          row.getString(2) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
-          row.getBoolean(3) should be(false)
-          row.getString(4) should be("README.md")
-        case (i, _) if i > 3 => fail("commits not expected")
-        case _ =>
-      }, total = 4, columnsCount = 5
+          row.getBoolean(5) should be(false)
+        case (_, row) =>
+          row.getString(3) should be("refs/heads/HEAD")
+      }, total = 4, columnsCount = columns.length
     )
+
   }
 
-  "BlobIterator" should "filter repositories if given" in {
-    val refFilters = Seq(EqualFilter(Attr("reference_name", "commits"), "refs/heads/HEAD"))
+  it should "filter repositories if given" in {
+    val refFilters = Seq(EqualFilter(
+      Attr("repository_id", "references"),
+      "github.com/mawag/faq-xiyoulinux"
+    ))
 
     testIterator(
       new BlobIterator(
-        Array(
-          "file_hash",
-          "content",
-          "commit_hash",
-          "is_binary",
-          "path"
-        ), _, null, refFilters), {
+        columns, _, null, refFilters), {
         case (0, row) =>
           row.getString(0) should be("733c072369ca77331f392c40da7404c85c36542c")
-          new String(row.getAs[Array[Byte]](1), StandardCharsets.UTF_8)
+          row.getString(1) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
+          row.getString(2) should be("github.com/mawag/faq-xiyoulinux")
+          row.getString(3) should be("refs/heads/HEAD")
+          new String(row.getAs[Array[Byte]](4), StandardCharsets.UTF_8)
             .should(startWith("                    GNU GENERAL PUBLIC LICENSE"))
-          row.getString(2) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
-          row.getBoolean(3) should be(false)
-          row.getString(4) should be("LICENSE")
+          row.getBoolean(5) should be(false)
         case (1, row) =>
           row.getString(0) should be("2d2ad68c14c51e62595125b86b464427f6bf2126")
-          new String(row.getAs[Array[Byte]](1), StandardCharsets.UTF_8)
+          row.getString(1) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
+          row.getString(2) should be("github.com/mawag/faq-xiyoulinux")
+          row.getString(3) should be("refs/heads/HEAD")
+          new String(row.getAs[Array[Byte]](4), StandardCharsets.UTF_8)
             .should(startWith("# faq-xiyoulinux"))
-          row.getString(2) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
-          row.getBoolean(3) should be(false)
-          row.getString(4) should be("README.md")
-        case (2, row) =>
-          row.getString(0) should be("733c072369ca77331f392c40da7404c85c36542c")
-          new String(row.getAs[Array[Byte]](1), StandardCharsets.UTF_8)
-            .should(startWith("                    GNU GENERAL PUBLIC LICENSE"))
-          row.getString(2) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
-          row.getBoolean(3) should be(false)
-          row.getString(4) should be("LICENSE")
-        case (3, row) =>
-          row.getString(0) should be("2d2ad68c14c51e62595125b86b464427f6bf2126")
-          new String(row.getAs[Array[Byte]](1), StandardCharsets.UTF_8)
-            .should(startWith("# faq-xiyoulinux"))
-          row.getString(2) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
-          row.getBoolean(3) should be(false)
-          row.getString(4) should be("README.md")
-
-        case (i, _) if i > 3 => fail("commits not expected")
-        case _ =>
-
-      }, total = 4, columnsCount = 5
+          row.getBoolean(5) should be(false)
+        case (_, row) =>
+          row.getString(2) should be("github.com/mawag/faq-xiyoulinux")
+      }, total = 2139, columnsCount = columns.length
     )
   }
 
-  "BlobIterator" should "return only files for given hashes if they are given" in {
+  it should "filter commits and return only blobs of the given commit" in {
+    val refFilters = Seq(EqualFilter(
+      Attr("commit_hash", "commits"), "fff7062de8474d10a67d417ccea87ba6f58ca81d")
+    )
+
+    testIterator(repo =>
+      new BlobIterator(
+        columns, repo, null, refFilters), {
+      case (_, row) =>
+        row.getString(1) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
+    }, total = 86, columnsCount = columns.length
+    )
+  }
+
+  it should "return only blobs for given hashes if they are given" in {
+    val commits = Array(
+      "a574356dab47de78259713af2f62955408395974",
+      "fff7062de8474d10a67d417ccea87ba6f58ca81d"
+    )
     val filters = Array[CompiledFilter](
-      InFilter(Attr("hash", "commits"), Array(
-        "a574356dab47de78259713af2f62955408395974",
-        "fff7062de8474d10a67d417ccea87ba6f58ca81d"
-      ))
+      InFilter(Attr("hash", "commits"), commits)
     )
 
     testIterator(repo =>
       new BlobIterator(
-        Array(
-          "file_hash",
-          "content",
-          "commit_hash",
-          "is_binary",
-          "path"
-        ),
+        columns,
         repo,
-        new CommitIterator(
-          Array("hash"),
+        new TreeEntryIterator(
+          Array("blob"),
           repo,
-          null,
-          filters
-        ),
-        Seq()
-      ), {
-      case (0, row) =>
-        row.getString(0) should be("733c072369ca77331f392c40da7404c85c36542c")
-        new String(row.getAs[Array[Byte]](1), StandardCharsets.UTF_8)
-          .should(startWith("                    GNU GENERAL PUBLIC LICENSE"))
-        row.getString(2) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
-        row.getBoolean(3) should be(false)
-        row.getString(4) should be("LICENSE")
-      case (1, row) =>
-        row.getString(0) should be("2d2ad68c14c51e62595125b86b464427f6bf2126")
-        new String(row.getAs[Array[Byte]](1), StandardCharsets.UTF_8)
-          .should(startWith("# faq-xiyoulinux"))
-        row.getString(2) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
-        row.getBoolean(3) should be(false)
-        row.getString(4) should be("README.md")
-      case _ =>
-
-    }, total = 12, columnsCount = 5
-    )
-  }
-
-  "BlobIterator" should "return only files for given hashes and repos if they are given" in {
-    testIterator(repo =>
-      new BlobIterator(
-        Array(
-          "file_hash",
-          "content",
-          "commit_hash",
-          "is_binary",
-          "path"
-        ),
-        repo,
-        new CommitIterator(
-          Array("hash"),
-          repo,
-          new ReferenceIterator(
-            Array("name"),
+          new CommitIterator(
+            Array("commit_hash"),
             repo,
-            new RepositoryIterator(
-              Array("id"),
-              repo,
-              Seq(EqualFilter(
-                Attr("id", "repositories"),
-                "github.com/xiyou-linuxer/faq-xiyoulinux"
-              ))
-            ),
-            Seq()
+            null,
+            filters
           ),
-          Seq(InFilter(Attr("hash", "commits"), Array(
-            "fff7062de8474d10a67d417ccea87ba6f58ca81d",
-            "f9e36cc24da9d36bab1222ae7e81a783dab83dd0"
-          )))
+          Seq()
         ),
         Seq()
       ), {
-      case (0, row) =>
-        row.getString(0) should be("733c072369ca77331f392c40da7404c85c36542c")
-        new String(row.getAs[Array[Byte]](1), StandardCharsets.UTF_8)
-          .should(startWith("                    GNU GENERAL PUBLIC LICENSE"))
-        row.getString(2) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
-        row.getBoolean(3) should be(false)
-        row.getString(4) should be("LICENSE")
-      case (1, row) =>
-        row.getString(0) should be("2d2ad68c14c51e62595125b86b464427f6bf2126")
-        new String(row.getAs[Array[Byte]](1), StandardCharsets.UTF_8)
-          .should(startWith("# faq-xiyoulinux"))
-        row.getString(2) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
-        row.getBoolean(3) should be(false)
-        row.getString(4) should be("README.md")
+      case (_, row) =>
+        commits should contain(row.getString(1))
       case _ =>
-    }, total = 2, columnsCount = 5
+
+    }, total = 476, columnsCount = columns.length
     )
   }
 
-  "BlobIterator" should "not fail with other, un-supported filters" in {
-    val filters = Array[CompiledFilter](EqualFilter(Attr("path", "files"), "README"))
-
-    testIterator(
+  it should "return only blobs for given hashes and repos if they are given" in {
+    val commits = Array(
+      "fff7062de8474d10a67d417ccea87ba6f58ca81d",
+      "f9e36cc24da9d36bab1222ae7e81a783dab83dd0"
+    )
+    testIterator(repo =>
       new BlobIterator(
-        Array(
-          "file_hash",
-          "content",
-          "commit_hash",
-          "is_binary",
-          "path"
-        ), _, null, filters), {
-        case _ =>
-      }, total = 22187, columnsCount = 5)
+        columns,
+        repo,
+        new TreeEntryIterator(
+          Array("blob"),
+          repo,
+          new CommitIterator(
+            Array("hash"),
+            repo,
+            new ReferenceIterator(
+              Array("name"),
+              repo,
+              new RepositoryIterator(
+                Array("id"),
+                repo,
+                Seq(EqualFilter(
+                  Attr("id", "repositories"),
+                  "github.com/xiyou-linuxer/faq-xiyoulinux"
+                ))
+              ),
+              Seq()
+            ),
+            Seq(InFilter(Attr("hash", "commits"), commits))
+          ),
+          Seq()
+        ),
+        Seq()
+      ), {
+      case (_, row) =>
+        commits should contain(row.getString(1))
+        row.getString(2) should be("github.com/xiyou-linuxer/faq-xiyoulinux")
+      case _ =>
+    }, total = 72, columnsCount = columns.length
+    )
   }
 
+  it should "not fail with other, un-supported filters" in {
+    val filters = Array[CompiledFilter](EqualFilter(Attr("message", "commits"), "README"))
+
+    testIterator(repo =>
+      new BlobIterator(columns, repo, null, filters)
+      , (_, _) => (),
+      total = 22187,
+      columnsCount = columns.length
+    )
+  }
 }

--- a/src/test/scala/tech/sourced/engine/iterator/CommitIteratorSpec.scala
+++ b/src/test/scala/tech/sourced/engine/iterator/CommitIteratorSpec.scala
@@ -14,8 +14,6 @@ class CommitIteratorSpec extends FlatSpec with BaseRootedRepoIterator {
     "hash",
     "message",
     "parents",
-    "tree",
-    "blobs",
     "parents_count",
     "author_email",
     "author_name",
@@ -36,22 +34,13 @@ class CommitIteratorSpec extends FlatSpec with BaseRootedRepoIterator {
           row.getString(3) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
           row.getString(4) should be("Initial commit\n")
           row.getAs[Array[String]](5) should be(Array())
-          row.getAs[Map[String, String]](6) should be(
-            Map(
-              "LICENSE" -> "733c072369ca77331f392c40da7404c85c36542c",
-              "README.md" -> "2d2ad68c14c51e62595125b86b464427f6bf2126"
-            )
-          )
-          row.getAs[Array[String]](7) should be(
-            Array("733c072369ca77331f392c40da7404c85c36542c",
-              "2d2ad68c14c51e62595125b86b464427f6bf2126"))
-          row.getInt(8) should be(0)
-          row.getString(9) should be("wangbo2008@vip.qq.com")
-          row.getString(10) should be("wangbo")
-          row.getTimestamp(11) should be(new Timestamp(1438072751000L))
-          row.getString(12) should be("wangbo2008@vip.qq.com")
-          row.getString(13) should be("wangbo")
-          row.getTimestamp(14) should be(new Timestamp(1438072751000L))
+          row.getInt(6) should be(0)
+          row.getString(7) should be("wangbo2008@vip.qq.com")
+          row.getString(8) should be("wangbo")
+          row.getTimestamp(9) should be(new Timestamp(1438072751000L))
+          row.getString(10) should be("wangbo2008@vip.qq.com")
+          row.getString(11) should be("wangbo")
+          row.getTimestamp(12) should be(new Timestamp(1438072751000L))
         case (1, row) =>
           row.getString(0) should be("github.com/mawag/faq-xiyoulinux")
           row.getString(1) should be("refs/heads/HEAD")
@@ -59,22 +48,13 @@ class CommitIteratorSpec extends FlatSpec with BaseRootedRepoIterator {
           row.getString(3) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
           row.getString(4) should be("Initial commit\n")
           row.getAs[Array[String]](5) should be(Array())
-          row.getAs[Map[String, String]](6) should be(
-            Map(
-              "LICENSE" -> "733c072369ca77331f392c40da7404c85c36542c",
-              "README.md" -> "2d2ad68c14c51e62595125b86b464427f6bf2126"
-            )
-          )
-          row.getAs[Array[String]](7) should be(
-            Array("733c072369ca77331f392c40da7404c85c36542c",
-              "2d2ad68c14c51e62595125b86b464427f6bf2126"))
-          row.getInt(8) should be(0)
-          row.getString(9) should be("wangbo2008@vip.qq.com")
-          row.getString(10) should be("wangbo")
-          row.getTimestamp(11) should be(new Timestamp(1438072751000L))
-          row.getString(12) should be("wangbo2008@vip.qq.com")
-          row.getString(13) should be("wangbo")
-          row.getTimestamp(14) should be(new Timestamp(1438072751000L))
+          row.getInt(6) should be(0)
+          row.getString(7) should be("wangbo2008@vip.qq.com")
+          row.getString(8) should be("wangbo")
+          row.getTimestamp(9) should be(new Timestamp(1438072751000L))
+          row.getString(10) should be("wangbo2008@vip.qq.com")
+          row.getString(11) should be("wangbo")
+          row.getTimestamp(12) should be(new Timestamp(1438072751000L))
         case (23, row) =>
           row.getString(0) should be("github.com/xiyou-linuxer/faq-xiyoulinux")
           row.getString(1) should be("refs/heads/develop")
@@ -84,73 +64,21 @@ class CommitIteratorSpec extends FlatSpec with BaseRootedRepoIterator {
           row.getAs[Array[String]](5) should be(
             Array("531f574cf8c457cbeb4f6a5bae2d81db22c5dc1a",
               "8331656181f9040d805b729946b12fd4382c4665"))
-          row.getAs[Map[String, String]](6) should be(
-            Map(
-              "source/search.php" -> "be1dd14a91679b91151357fc37a84fc6b59be1a6",
-              "source/config/db.simple.config.php" -> "a7b19793b35a11d92ee4594829e23392ddf11f79",
-              "source/includes/oauth.class.php" -> "95d9b676fc34a4a2c352c905242b03740fe5d2f2",
-              "source/oauth/login.php" -> "935780f405f7602ac5008792c73aa932762b4013",
-              "source/includes/errshow.class.php" -> "389f98e2d60c5839812ea5bbd2fef0941929a47c",
-              "source/includes/show.function.php" -> "3c36e3c735d6411855dee5eaa0b83f378b05341e",
-              "README.md" -> "2d2ad68c14c51e62595125b86b464427f6bf2126",
-              "source/addquestion.php" -> "97030825f145faee7fb1b275c16b0c369f763ec2",
-              "source/index.php" -> "c0e106625193a645af54fda2762d879c990e728e",
-              "source/includes/user.class.php" -> "32abf82d6c3b9203b28eb4784a4ad70bdfc3bf0c",
-              "source/init.php" -> "42073993b9a76a4cb8af9d6bece8bd7e7a65ab19",
-              ".gitignore" -> "047b4a9cfea20a4485b5413a8771e98f7aa1a5c7",
-              "docs/class_user接口规范.docx" -> "9ed4707aafb7fab4aa1289b8f44e1c3c2942b2e6",
-              "source/includes/index.function.php" -> "9d2fd6ebbb938b6936f5a8beda2e72a3c2acf35b",
-              "source/question.php" -> "2453ceecbd5a60937db12ba2886197b3d6cb793d",
-              "source/oauth/index.php" -> "e64428200e23f2891d9f1fb8ac6e73270558fcf8",
-              "source/includes/db_function.class.php" -> "186255ff7f0b4973d8ec11a5f5aa0ff92f70c24e",
-              "source/includes/db.class.php" -> "04da61f5a68624459dbb89c7f9324bca80f7041d",
-              ".gitmodules" -> "a206844708eca67b4221c97d7d5dd39127b4fd95",
-              "source/view" -> "3558dd448c31f10f3e1b518c39d633fc9396cb69",
-              "source/config/oauth.simple.config.php" -> "2d2a7516fa6e64ba9487f6ae9396335eb9b15704",
-              "LICENSE" -> "733c072369ca77331f392c40da7404c85c36542c"
-            )
-          )
-          row.getAs[Array[String]](7) should be(
-            Array(
-              "be1dd14a91679b91151357fc37a84fc6b59be1a6",
-              "a7b19793b35a11d92ee4594829e23392ddf11f79",
-              "95d9b676fc34a4a2c352c905242b03740fe5d2f2",
-              "935780f405f7602ac5008792c73aa932762b4013",
-              "389f98e2d60c5839812ea5bbd2fef0941929a47c",
-              "3c36e3c735d6411855dee5eaa0b83f378b05341e",
-              "2d2ad68c14c51e62595125b86b464427f6bf2126",
-              "97030825f145faee7fb1b275c16b0c369f763ec2",
-              "c0e106625193a645af54fda2762d879c990e728e",
-              "32abf82d6c3b9203b28eb4784a4ad70bdfc3bf0c",
-              "42073993b9a76a4cb8af9d6bece8bd7e7a65ab19",
-              "047b4a9cfea20a4485b5413a8771e98f7aa1a5c7",
-              "9ed4707aafb7fab4aa1289b8f44e1c3c2942b2e6",
-              "9d2fd6ebbb938b6936f5a8beda2e72a3c2acf35b",
-              "2453ceecbd5a60937db12ba2886197b3d6cb793d",
-              "e64428200e23f2891d9f1fb8ac6e73270558fcf8",
-              "186255ff7f0b4973d8ec11a5f5aa0ff92f70c24e",
-              "04da61f5a68624459dbb89c7f9324bca80f7041d",
-              "a206844708eca67b4221c97d7d5dd39127b4fd95",
-              "3558dd448c31f10f3e1b518c39d633fc9396cb69",
-              "2d2a7516fa6e64ba9487f6ae9396335eb9b15704",
-              "733c072369ca77331f392c40da7404c85c36542c"
-            )
-          )
-          row.getInt(8) should be(2)
-          row.getString(9) should be("1679211339@qq.com")
-          row.getString(10) should be("磊磊")
-          row.getTimestamp(11) should be(new Timestamp(1439552359000L))
-          row.getString(12) should be("1679211339@qq.com")
-          row.getString(13) should be("磊磊")
-          row.getTimestamp(14) should be(new Timestamp(1439552359000L))
+          row.getInt(6) should be(2)
+          row.getString(7) should be("1679211339@qq.com")
+          row.getString(8) should be("磊磊")
+          row.getTimestamp(9) should be(new Timestamp(1439552359000L))
+          row.getString(10) should be("1679211339@qq.com")
+          row.getString(11) should be("磊磊")
+          row.getTimestamp(12) should be(new Timestamp(1439552359000L))
         case (i, _) if i > 1061 => fail("commits not expected")
 
         case _ =>
-      }, total = 1062, columnsCount = 15
+      }, total = 1062, columnsCount = 13
     )
   }
 
-  "CommitIterator" should "return all commits from all repositories into a siva file, " +
+  it should "return all commits from all repositories into a siva file, " +
     "filtering columns" in {
     testIterator(
       new CommitIterator(
@@ -175,7 +103,7 @@ class CommitIteratorSpec extends FlatSpec with BaseRootedRepoIterator {
     )
   }
 
-  "CommitIterator" should "apply passed filters" in {
+  it should "apply passed filters" in {
     val commits = Array(
       "fff7062de8474d10a67d417ccea87ba6f58ca81d",
       "531f574cf8c457cbeb4f6a5bae2d81db22c5dc1a"
@@ -205,7 +133,7 @@ class CommitIteratorSpec extends FlatSpec with BaseRootedRepoIterator {
     )
   }
 
-  "CommitIterator" should "apply use prev iterator" in {
+  it should "apply use prev iterator" in {
     val commits = Array(
       "fff7062de8474d10a67d417ccea87ba6f58ca81d",
       "531f574cf8c457cbeb4f6a5bae2d81db22c5dc1a"

--- a/src/test/scala/tech/sourced/engine/iterator/ReferenceIteratorSpec.scala
+++ b/src/test/scala/tech/sourced/engine/iterator/ReferenceIteratorSpec.scala
@@ -25,7 +25,7 @@ class ReferenceIteratorSpec extends FlatSpec with BaseRootedRepoIterator {
     )
   }
 
-  "ReferenceIterator" should "return only specified columns" in {
+  it should "return only specified columns" in {
     testIterator(
       new ReferenceIterator(Array("repository_id", "name"), _, null, Seq()), {
         case (0, row) =>
@@ -42,7 +42,7 @@ class ReferenceIteratorSpec extends FlatSpec with BaseRootedRepoIterator {
     )
   }
 
-  "ReferenceIterator" should "apply passed filters" in {
+  it should "apply passed filters" in {
     testIterator(
       new ReferenceIterator(
         Array("repository_id", "name"),
@@ -60,7 +60,7 @@ class ReferenceIteratorSpec extends FlatSpec with BaseRootedRepoIterator {
     )
   }
 
-  "ReferenceIterator" should "use previously passed iterator" in {
+  it should "use previously passed iterator" in {
     testIterator(repo =>
       new ReferenceIterator(
         Array("repository_id", "name"),

--- a/src/test/scala/tech/sourced/engine/iterator/TreeEntryIteratorSpec.scala
+++ b/src/test/scala/tech/sourced/engine/iterator/TreeEntryIteratorSpec.scala
@@ -1,0 +1,128 @@
+package tech.sourced.engine.iterator
+
+import org.scalatest.FlatSpec
+import tech.sourced.engine.util.{Attr, EqualFilter}
+
+class TreeEntryIteratorSpec extends FlatSpec with BaseRootedRepoIterator {
+
+  private val cols = Array(
+    "commit_hash",
+    "repository_id",
+    "reference_name",
+    "path",
+    "blob"
+  )
+
+  "TreeEntryIterator" should "return all tree entries from all commits " +
+    "from all repositories into a siva file" in {
+    testIterator(
+      new TreeEntryIterator(
+        cols, _, null, Seq()), {
+        case (0, row) =>
+          row.getString(0) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
+          row.getString(1) should be("github.com/xiyou-linuxer/faq-xiyoulinux")
+          row.getString(2) should be("refs/heads/HEAD")
+          row.getString(3) should be("LICENSE")
+          row.getString(4) should be("733c072369ca77331f392c40da7404c85c36542c")
+        case (1, row) =>
+          row.getString(0) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
+          row.getString(1) should be("github.com/xiyou-linuxer/faq-xiyoulinux")
+          row.getString(2) should be("refs/heads/HEAD")
+          row.getString(3) should be("README.md")
+          row.getString(4) should be("2d2ad68c14c51e62595125b86b464427f6bf2126")
+        case (2, row) =>
+          row.getString(0) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
+          row.getString(1) should be("github.com/mawag/faq-xiyoulinux")
+          row.getString(2) should be("refs/heads/HEAD")
+          row.getString(3) should be("LICENSE")
+          row.getString(4) should be("733c072369ca77331f392c40da7404c85c36542c")
+        case (3, row) =>
+          row.getString(0) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
+          row.getString(1) should be("github.com/mawag/faq-xiyoulinux")
+          row.getString(2) should be("refs/heads/HEAD")
+          row.getString(3) should be("README.md")
+          row.getString(4) should be("2d2ad68c14c51e62595125b86b464427f6bf2126")
+        case _ =>
+      }, total = 23189, columnsCount = cols.length
+    )
+  }
+
+  it should "filter by path" in {
+    val filters = Seq(EqualFilter(
+      Attr("path", "tree_entries"),
+      "README.md")
+    )
+
+    testIterator(
+      new TreeEntryIterator(
+        cols, _, null, filters), {
+        case (_, r) =>
+          r.getString(3) should be("README.md")
+      }, total = 1062, columnsCount = cols.length
+    )
+  }
+
+  it should "filter by blob" in {
+    val filters = Seq(EqualFilter(
+      Attr("blob", "tree_entries"),
+      "733c072369ca77331f392c40da7404c85c36542c")
+    )
+
+    testIterator(
+      new TreeEntryIterator(
+        cols, _, null, filters), {
+        case (_, r) =>
+          r.getString(4) should be("733c072369ca77331f392c40da7404c85c36542c")
+      }, total = 1062, columnsCount = cols.length
+    )
+  }
+
+  it should "work when it's chained" in {
+    val filters = Seq(EqualFilter(
+      Attr("hash", "commits"),
+      "fff7062de8474d10a67d417ccea87ba6f58ca81d")
+    )
+
+    testIterator(repo =>
+      new TreeEntryIterator(
+        cols,
+        repo,
+        new CommitIterator(Array("hash"), repo, null, filters),
+        Seq()
+      ), {
+      case (i, r) if i % 2 == 0 =>
+        r.getString(4) should be("733c072369ca77331f392c40da7404c85c36542c")
+        r.getString(3) should be("LICENSE")
+        r.getString(0) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
+
+      case (_, r) =>
+        r.getString(4) should be("2d2ad68c14c51e62595125b86b464427f6bf2126")
+        r.getString(3) should be("README.md")
+        r.getString(0) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
+    }, total = 86, columnsCount = cols.length
+    )
+  }
+
+  it should "filter by commit hash" in {
+    val filters = Seq(EqualFilter(
+      Attr("commit_hash", "tree_entries"),
+      "fff7062de8474d10a67d417ccea87ba6f58ca81d")
+    )
+
+    testIterator(
+      new TreeEntryIterator(
+        cols, _, null, filters), {
+        case (i, r) if i % 2 == 0 =>
+          r.getString(4) should be("733c072369ca77331f392c40da7404c85c36542c")
+          r.getString(3) should be("LICENSE")
+          r.getString(0) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
+
+        case (_, r) =>
+          r.getString(4) should be("2d2ad68c14c51e62595125b86b464427f6bf2126")
+          r.getString(3) should be("README.md")
+          r.getString(0) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
+      }, total = 86, columnsCount = cols.length
+    )
+  }
+
+}


### PR DESCRIPTION
Closes #172 

This introduces two new tables tree_entries and blobs, and removes the files table as well as the tree and blobs fields from the commit table.
Other significant changes are:
- Join conditions inside GitOptimizer are now prepended to the relation as a filter node, removing all the redundant filters, such as repository_id = id and so on that are taken care of inside the iterators themselves.
- Now getting the blobs without using `getFirstReferenceCommit` is heavier, because it returns way more data, so the usage if said method is highly encouraged. To get the exact same results as before, adding `.drop("repository_id", "reference_name").distinct()` to the end of the chain does the trick.
- repository_id, commit_hash and reference_name make it all the way to the blobs now.
- blobs are cached inside the BlobIterator so one blob may only have to be read once per partition.

**WARNING:** this contains several breaking changes.

### Tasks

- [x] Scala changes
- [x] Python changes
- [x] Changes in docs, guides and examples