### PR TITLE
Moved storage level test to a new class

### DIFF
--- a/src/test/scala/tech/sourced/engine/BaseSparkSpec.scala
+++ b/src/test/scala/tech/sourced/engine/BaseSparkSpec.scala
@@ -1,6 +1,5 @@
 package tech.sourced.engine
 
-import org.apache.log4j.{Level, Logger}
 import org.apache.spark.sql.SparkSession
 import org.scalatest.{BeforeAndAfterAll, Suite}
 

--- a/src/test/scala/tech/sourced/engine/DefaultSourceSpec.scala
+++ b/src/test/scala/tech/sourced/engine/DefaultSourceSpec.scala
@@ -66,26 +66,6 @@ class DefaultSourceSpec extends FlatSpec with Matchers with BaseSivaSpec with Ba
     out should be(37)
   }
 
-  it should "work with all storage levels" in {
-    import org.apache.spark.storage.StorageLevel._
-    val storageLevels = List(
-      DISK_ONLY,
-      DISK_ONLY_2,
-      MEMORY_AND_DISK,
-      MEMORY_AND_DISK_2,
-      MEMORY_AND_DISK_SER,
-      MEMORY_AND_DISK_SER_2,
-      MEMORY_ONLY,
-      MEMORY_ONLY_2,
-      MEMORY_ONLY_SER,
-      MEMORY_ONLY_SER_2,
-      NONE,
-      OFF_HEAP
-    )
-
-    storageLevels.foreach(engine.getRepositories.persist(_).count)
-  }
-
   "Convenience for getting files" should "work without reading commits" in {
     val spark = ss
     import spark.implicits._

--- a/src/test/scala/tech/sourced/engine/StorageLevelSpec.scala
+++ b/src/test/scala/tech/sourced/engine/StorageLevelSpec.scala
@@ -1,0 +1,37 @@
+package tech.sourced.engine
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class StorageLevelSpec  extends FlatSpec with Matchers with BaseSivaSpec with BaseSparkSpec {
+
+  var engine: Engine = _
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    engine = Engine(ss, resourcePath)
+  }
+
+  "A Dataframe" should "work with all storage levels" in {
+    import org.apache.spark.storage.StorageLevel._
+    val storageLevels = List(
+      DISK_ONLY,
+      DISK_ONLY_2,
+      MEMORY_AND_DISK,
+      MEMORY_AND_DISK_2,
+      MEMORY_AND_DISK_SER,
+      MEMORY_AND_DISK_SER_2,
+      MEMORY_ONLY,
+      MEMORY_ONLY_2,
+      MEMORY_ONLY_SER,
+      MEMORY_ONLY_SER_2,
+      NONE,
+      OFF_HEAP
+    )
+
+    storageLevels.foreach(level => {
+      val df = engine.getRepositories.persist(level)
+      df.count()
+      df.unpersist()
+    })
+  }
+}


### PR DESCRIPTION
Since persist is bound to a `SparkContext` and we reuse the same `SparkSession` for all the tests in `DefaultSourceSpec`, the storage level test has been located in a new class that use a different `SparkSession` to avoid erros in other tests that are not related.