### PR TITLE
Fix travis to use the right bblfsh image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ matrix:
             tags: true
 
 before_script:
-  - docker run --privileged -d -p 9432:9432 --name bblfsh bblfsh/server
+  - make docker-bblfsh
 
 script:
   - make travis-test


### PR DESCRIPTION
Changed the docker command which were using the old `bblfsh/server` image by the `make docker-bblfsh` command that uses the `bblfsh/bblfshd`image.