### PR TITLE
build: not include not provided deps on pom.xml, scala as provided

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,9 @@ logBuffered in Test := false
 
 assemblyShadeRules in assembly := Seq(
   ShadeRule.rename("com.google.common.**" -> "com.google.shadedcommon.@1").inAll,
-  ShadeRule.rename("io.netty.**" -> "io.shadednetty.@1").inAll
+  ShadeRule.rename("io.netty.**" -> "io.shadednetty.@1").inAll,
+  ShadeRule.rename("org.apache.commons.**" -> "org.apache.shadedcommons.@1").inAll,
+  ShadeRule.rename("org.eclipse.jgit.**" -> "org.eclipse.shadedjgit.@1").inAll
 )
 
 assemblyMergeStrategy in assembly := {
@@ -80,13 +82,14 @@ pomPostProcess := { (node: scala.xml.Node) =>
     override def transform(n: Node): Seq[Node] = n match {
       case e: Elem if e.label == "dependencies" =>
         <dependencies>
-          {e.child}
-          <dependency>
-            <groupId>org.scala-lang</groupId>
-            <artifactId>scala-library</artifactId>
-            <version>{scalaVersion.value}</version>
-            <scope>provided</scope>
-          </dependency>
+          {e.child}<dependency>
+          <groupId>org.scala-lang</groupId>
+          <artifactId>scala-library</artifactId>
+          <version>
+            {scalaVersion.value}
+          </version>
+          <scope>provided</scope>
+        </dependency>
         </dependencies>
       case e: Elem if e.label == "dependency"
         && e.child.exists(child => child.label == "scope" && child.text == "provided") =>

--- a/build.sbt
+++ b/build.sbt
@@ -20,6 +20,9 @@ libraryDependencies += bblfsh % Compile
 libraryDependencies += commonsIO % Compile
 libraryDependencies += commonsPool % Compile
 libraryDependencies += enry % Compile
+libraryDependencies += scalaLib % Provided
+
+assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false)
 
 testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oUT")
 
@@ -68,6 +71,39 @@ pomIncludeRepository := (_ => false)
 
 crossPaths := false
 publishMavenStyle := true
+
+pomPostProcess := { (node: scala.xml.Node) =>
+  import scala.xml._
+  import scala.xml.transform._
+
+  object DependencyEraser extends RewriteRule {
+    override def transform(n: Node): Seq[Node] = n match {
+      case e: Elem if e.label == "dependencies" =>
+        <dependencies>
+          {e.child}
+          <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+            <version>{scalaVersion.value}</version>
+            <scope>provided</scope>
+          </dependency>
+        </dependencies>
+      case e: Elem if e.label == "dependency"
+        && e.child.exists(child => child.label == "scope" && child.text == "provided") =>
+        e
+      case e: Elem if e.label == "dependency" =>
+        val organization = e.child.filter(_.label == "groupId").flatMap(_.text).mkString
+        val artifact = e.child.filter(_.label == "artifactId").flatMap(_.text).mkString
+        val version = e.child.filter(_.label == "version").flatMap(_.text).mkString
+        Comment(s" not provided dependency $organization#$artifact;$version has been omitted ")
+      case other => other
+    }
+  }
+
+  object eraseDependencies extends RuleTransformer(DependencyEraser)
+
+  eraseDependencies(node)
+}
 
 val SONATYPE_USERNAME = scala.util.Properties.envOrElse("SONATYPE_USERNAME", "NOT_SET")
 val SONATYPE_PASSWORD = scala.util.Properties.envOrElse("SONATYPE_PASSWORD", "NOT_SET")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,5 +12,5 @@ object Dependencies {
   lazy val enry = "tech.sourced" % "enry-java" % "1.6.1"
   lazy val commonsIO = "commons-io" % "commons-io" % "2.5"
   lazy val commonsPool = "org.apache.commons" % "commons-pool2" % "2.4.3"
-
+  lazy val scalaLib = "org.scala-lang" % "scala-library" % "2.11.11"
 }


### PR DESCRIPTION
Fixes #210 

- Not include scala in fatjar
- Mark scala as provided
- Rewrite output `pom.xml` to remove all dependencies without `provided` scope and add the scala library as provided (since sbt or something else in the process adds it as compile even if you explicitly put it).

**NOTE:** this only works for maven repositories. That is, if you use `publishLocal`, it will not work, you need to use `publishM2` and use the local maven repository. Since we deploy on maven it should not matter much.

![I'll let myself out](https://media0.giphy.com/media/3KWHzadf2Iq64/giphy.gif)