### PR TITLE
Added rule to attach source to attributes

### DIFF
--- a/src/main/scala/tech/sourced/engine/DefaultSource.scala
+++ b/src/main/scala/tech/sourced/engine/DefaultSource.scala
@@ -8,7 +8,7 @@ import org.apache.spark.sql.{Row, SQLContext, SparkSession}
 import org.apache.spark.{SparkException, UtilsWrapper}
 import tech.sourced.engine.iterator._
 import tech.sourced.engine.provider.{RepositoryProvider, RepositoryRDDProvider}
-import tech.sourced.engine.util.Filter
+import tech.sourced.engine.util.{CompiledFilter, Filter}
 
 /**
   * Default source to provide new git relations.
@@ -156,8 +156,7 @@ private object GitRelation {
     * @param schema      resultant schema
     * @return sequence with table sources
     */
-  private def getSources(tableSource: Option[String],
-                         schema: StructType): Seq[String] =
+  private def getSources(tableSource: Option[String], schema: StructType): Seq[String] =
     tableSource match {
       case Some(ts) => Seq(ts)
       case None =>
@@ -173,7 +172,7 @@ private object GitRelation {
     * @param filters list of expression to compile the filters
     * @return compiled and grouped filters
     */
-  private def getFiltersBySource(filters: Seq[Expression]) =
+  private def getFiltersBySource(filters: Seq[Expression]): Map[String, Seq[CompiledFilter]] =
     filters.map(Filter.compile)
       .flatMap(_.filters)
       .map(e => (e.sources.distinct, e))

--- a/src/main/scala/tech/sourced/engine/Engine.scala
+++ b/src/main/scala/tech/sourced/engine/Engine.scala
@@ -38,7 +38,7 @@ import scala.collection.JavaConversions.asScalaBuffer
 class Engine(session: SparkSession) {
 
   session.registerUDFs()
-  session.experimental.extraOptimizations = Seq(SquashGitRelationJoin)
+  session.experimental.extraOptimizations = Seq(AddSourceToAttributes, SquashGitRelationJoin)
 
   /**
     * Returns a DataFrame with the data about the repositories found at


### PR DESCRIPTION
Before this PR, the `source` assignation as metadata to `AttributeReference` was done in the `SquashGitRelationJoin` so a code like this didn't work properly:

```scala
val repoDf = engine.getRepositories
repoDf.where("id='github.com/xiyou-linuxer/faq-xiyoulinux'").show
```

It was filtered by spark instead of us because the `source` it wasn't  set.

Now there is a new rule `AddSourceToAttributes` ensuring the `source` is set always. 