### PR TITLE
Store metadata in a SQLite database

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,4 +81,3 @@ before_script:
 
 script:
   - make travis-test
-  - make build

--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,5 @@ docker-push: docker-build
 	fi;
 
 maven-release:
-	$(SBT) publishLocal && \
-	$(SBT) publishSigned && \
+	$(SBT) clean publishSigned && \
 	$(SBT) sonatypeRelease

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import sbt.Keys.libraryDependencies
 
 organization := "tech.sourced"
 scalaVersion := "2.11.11"
-version := "0.1.11"
+version := "0.1.12"
 name := "engine"
 
 libraryDependencies += scalaTest % Test

--- a/build.sbt
+++ b/build.sbt
@@ -21,6 +21,7 @@ libraryDependencies += commonsIO % Compile
 libraryDependencies += commonsPool % Compile
 libraryDependencies += enry % Compile
 libraryDependencies += scalaLib % Provided
+libraryDependencies += sqlite % Compile
 
 testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oUT")
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,4 +13,5 @@ object Dependencies {
   lazy val commonsIO = "commons-io" % "commons-io" % "2.5"
   lazy val commonsPool = "org.apache.commons" % "commons-pool2" % "2.4.3"
   lazy val scalaLib = "org.scala-lang" % "scala-library" % "2.11.11"
+  lazy val sqlite = "org.xerial" % "sqlite-jdbc" % "3.21.0"
 }

--- a/src/main/scala/tech/sourced/engine/DefaultSource.scala
+++ b/src/main/scala/tech/sourced/engine/DefaultSource.scala
@@ -8,7 +8,7 @@ import org.apache.spark.sql.{Row, SQLContext, SparkSession}
 import org.apache.spark.{SparkException, UtilsWrapper}
 import tech.sourced.engine.iterator._
 import tech.sourced.engine.provider.{RepositoryProvider, RepositoryRDDProvider}
-import tech.sourced.engine.util.Filter
+import tech.sourced.engine.util.{CompiledFilter, Filter}
 
 /**
   * Default source to provide new git relations.
@@ -156,8 +156,7 @@ private object GitRelation {
     * @param schema      resultant schema
     * @return sequence with table sources
     */
-  private def getSources(tableSource: Option[String],
-                         schema: StructType): Seq[String] =
+  private def getSources(tableSource: Option[String], schema: StructType): Seq[String] =
     tableSource match {
       case Some(ts) => Seq(ts)
       case None =>
@@ -173,7 +172,7 @@ private object GitRelation {
     * @param filters list of expression to compile the filters
     * @return compiled and grouped filters
     */
-  private def getFiltersBySource(filters: Seq[Expression]) =
+  private def getFiltersBySource(filters: Seq[Expression]): Map[String, Seq[CompiledFilter]] =
     filters.map(Filter.compile)
       .flatMap(_.filters)
       .map(e => (e.sources.distinct, e))

--- a/src/main/scala/tech/sourced/engine/DefaultSource.scala
+++ b/src/main/scala/tech/sourced/engine/DefaultSource.scala
@@ -98,6 +98,7 @@ case class GitRelation(session: SparkSession,
       sources.value.foreach({
         case k@"repositories" =>
           iter = Some(new RepositoryIterator(
+            source.root,
             requiredCols.value,
             repo,
             filtersBySource.value.getOrElse(k, Seq())

--- a/src/main/scala/tech/sourced/engine/Engine.scala
+++ b/src/main/scala/tech/sourced/engine/Engine.scala
@@ -38,7 +38,7 @@ import scala.collection.JavaConversions.asScalaBuffer
 class Engine(session: SparkSession) {
 
   session.registerUDFs()
-  session.experimental.extraOptimizations = Seq(SquashGitRelationJoin)
+  session.experimental.extraOptimizations = Seq(AddSourceToAttributes, SquashGitRelationJoin)
 
   /**
     * Returns a DataFrame with the data about the repositories found at

--- a/src/main/scala/tech/sourced/engine/Engine.scala
+++ b/src/main/scala/tech/sourced/engine/Engine.scala
@@ -1,8 +1,13 @@
 package tech.sourced.engine
 
+import java.util.Properties
+
+import org.apache.spark.sql.functions.{lit, when}
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.SparkException
+import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{DataFrame, SparkSession}
+import tech.sourced.engine.udf.ConcatArrayUDF
 
 import scala.collection.JavaConversions.asScalaBuffer
 
@@ -35,7 +40,7 @@ import scala.collection.JavaConversions.asScalaBuffer
   * @constructor creates a Engine instance with the given Spark session.
   * @param session Spark session to be used
   */
-class Engine(session: SparkSession) {
+class Engine(session: SparkSession) extends Logging {
 
   session.registerUDFs()
   session.experimental.extraOptimizations = Seq(AddSourceToAttributes, SquashGitRelationJoin)
@@ -158,6 +163,41 @@ class Engine(session: SparkSession) {
   def skipCleanup(skip: Boolean): Engine = {
     session.conf.set(skipCleanupKey, skip)
     this
+  }
+
+  def saveMetadata(folder: java.nio.file.Path): Unit = {
+    if (!folder.toFile.exists() || !folder.toFile.isDirectory) {
+      throw new SparkException("folder given to saveMetadata is not a directory " +
+        "or does not exist")
+    }
+
+    val dbFile = folder.resolve("engine_metadata.db")
+    if (dbFile.toFile.exists) {
+      log.warn(s"metadata file '$dbFile' already exists, it will be deleted")
+      dbFile.toFile.delete()
+    }
+
+    implicit val session: SparkSession = this.session
+
+    val properties = new Properties()
+    properties.put("driver", "org.sqlite.JDBC")
+    Seq("repositories", "references", "commits", "tree_entries").foreach {
+      table =>
+        val df = (table, getDataSource(table, session)) match {
+          case ("repositories", d) =>
+            d.withColumn("urls", ConcatArrayUDF(d("urls"), lit("|")))
+              .withColumn(
+                "is_fork",
+                when(d("is_fork") === false, 0)
+                  .otherwise(when(d("is_fork") === true, 1).otherwise(null))
+              )
+          case ("commits", d) =>
+            d.withColumn("parents", ConcatArrayUDF(d("parents"), lit("|")))
+          case (_, d) => d
+        }
+
+        df.write.jdbc(s"jdbc:sqlite:$dbFile", s"engine_$table", properties)
+    }
   }
 
 }

--- a/src/main/scala/tech/sourced/engine/Engine.scala
+++ b/src/main/scala/tech/sourced/engine/Engine.scala
@@ -62,7 +62,7 @@ class Engine(session: SparkSession) {
     * repositories.
     *
     * {{{
-    * val blobsDf = engine.getFiles(repoIds, refNames, hashes)
+    * val blobsDf = engine.getBlobs(repoIds, refNames, hashes)
     * }}}
     *
     * Calling this function with no arguments is the same as:

--- a/src/main/scala/tech/sourced/engine/Schema.scala
+++ b/src/main/scala/tech/sourced/engine/Schema.scala
@@ -15,6 +15,7 @@ private[engine] object Schema {
     StructField("id", StringType, nullable = false) ::
       StructField("urls", ArrayType(StringType, containsNull = false), nullable = false) ::
       StructField("is_fork", BooleanType) ::
+      StructField("repository_path", StringType) ::
       Nil
   )
 

--- a/src/main/scala/tech/sourced/engine/iterator/RepositoryIterator.scala
+++ b/src/main/scala/tech/sourced/engine/iterator/RepositoryIterator.scala
@@ -6,11 +6,13 @@ import tech.sourced.engine.util.{CompiledFilter, Filter}
 /**
   * Iterator that will return rows of repositories in a repository.
   *
-  * @param finalColumns final columns that must be in the resultant row
-  * @param repo         repository to get the data from
-  * @param filters      filters for the iterator
+  * @param repositoryPath path of the given repository
+  * @param finalColumns   final columns that must be in the resultant row
+  * @param repo           repository to get the data from
+  * @param filters        filters for the iterator
   */
-class RepositoryIterator(finalColumns: Array[String],
+class RepositoryIterator(repositoryPath: String,
+                         finalColumns: Array[String],
                          repo: Repository,
                          filters: Seq[CompiledFilter])
   extends RootedRepoIterator[String](finalColumns, repo, null, filters) {
@@ -19,11 +21,11 @@ class RepositoryIterator(finalColumns: Array[String],
   // we can cache here the matching cases, because they are not going to change.
   private val matchingFilters = filters.flatMap(_.matchingCases)
 
-  /** @inheritdoc */
+  /** @inheritdoc*/
   override protected def loadIterator(filters: Seq[CompiledFilter]): Iterator[String] =
     RepositoryIterator.loadIterator(repo, matchingFilters)
 
-  /** @inheritdoc */
+  /** @inheritdoc*/
   override protected def mapColumns(id: String): Map[String, () => Any] = {
     val c = repo.getConfig
     val remote = RootedRepo.getRepositoryRemote(repo, id)
@@ -35,7 +37,8 @@ class RepositoryIterator(finalColumns: Array[String],
     Map[String, () => Any](
       "id" -> (() => id),
       "urls" -> (() => urls),
-      "is_fork" -> (() => isFork)
+      "is_fork" -> (() => isFork),
+      "repository_path" -> (() => repositoryPath)
     )
   }
 

--- a/src/main/scala/tech/sourced/engine/package.scala
+++ b/src/main/scala/tech/sourced/engine/package.scala
@@ -392,7 +392,8 @@ package object engine {
       ExtractUASTsWithoutLangUDF,
       ExtractUASTsWithLangUDF,
       QueryXPathUDF,
-      ExtractTokensUDF
+      ExtractTokensUDF,
+      ConcatArrayUDF
     )
   }
 

--- a/src/main/scala/tech/sourced/engine/udf/ConcatArrayUDF.scala
+++ b/src/main/scala/tech/sourced/engine/udf/ConcatArrayUDF.scala
@@ -1,0 +1,24 @@
+package tech.sourced.engine.udf
+
+import gopkg.in.bblfsh.sdk.v1.uast.generated.Node
+import org.apache.spark.sql.expressions.UserDefinedFunction
+import org.apache.spark.sql.functions.udf
+import org.apache.spark.sql.{Column, SparkSession}
+import tech.sourced.engine.util.Bblfsh
+
+
+/** User defined function to concat array elements with the given separator. */
+case object ConcatArrayUDF extends CustomUDF {
+
+  override val name = "concatArray"
+
+  override def function(session: SparkSession): UserDefinedFunction = {
+    val configB = session.sparkContext.broadcast(Bblfsh.getConfig(session))
+    udf[String, Seq[String], String]((arr, sep) => arr.mkString(sep))
+  }
+
+  def apply(arr: Column, sep: Column)(implicit session: SparkSession): Column = {
+    function(session)(arr, sep)
+  }
+
+}

--- a/src/test/scala/tech/sourced/engine/EngineSpec.scala
+++ b/src/test/scala/tech/sourced/engine/EngineSpec.scala
@@ -1,0 +1,44 @@
+package tech.sourced.engine
+
+import java.nio.file.{Path, Paths}
+import java.util.{Properties, UUID}
+
+import org.apache.commons.io.FileUtils
+import org.scalatest.{FlatSpec, Matchers}
+
+class EngineSpec extends FlatSpec with Matchers with BaseSivaSpec with BaseSparkSpec {
+
+  var engine: Engine = _
+  var tmpPath: Path = _
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+
+    engine = Engine(ss, resourcePath)
+    tmpPath = Paths.get(System.getProperty("java.io.tmpdir"))
+      .resolve(UUID.randomUUID.toString)
+    tmpPath.toFile.mkdir()
+  }
+
+  override def afterAll(): Unit = {
+    super.afterAll()
+    FileUtils.deleteQuietly(tmpPath.toFile)
+  }
+
+  "saveMetadata" should "store all metadata tables in a SQLite db" in {
+    engine.saveMetadata(tmpPath)
+
+    val dbFile = tmpPath.resolve("engine_metadata.db")
+    dbFile.toFile.exists should be(true)
+
+    val properties = new Properties()
+    properties.put("driver", "org.sqlite.JDBC")
+    Seq("repositories", "references", "commits", "tree_entries").foreach {
+      table =>
+        val count = getDataSource(table, ss).count()
+        ss.read.jdbc(s"jdbc:sqlite:$dbFile", s"engine_$table", properties)
+          .count() should be(count)
+    }
+  }
+
+}

--- a/src/test/scala/tech/sourced/engine/iterator/BlobIteratorSpec.scala
+++ b/src/test/scala/tech/sourced/engine/iterator/BlobIteratorSpec.scala
@@ -189,6 +189,7 @@ class BlobIteratorSpec extends FlatSpec with BaseRootedRepoIterator {
               Array("name"),
               repo,
               new RepositoryIterator(
+                "/foo/bar",
                 Array("id"),
                 repo,
                 Seq(EqualFilter(

--- a/src/test/scala/tech/sourced/engine/iterator/CommitIteratorSpec.scala
+++ b/src/test/scala/tech/sourced/engine/iterator/CommitIteratorSpec.scala
@@ -151,6 +151,7 @@ class CommitIteratorSpec extends FlatSpec with BaseRootedRepoIterator {
           Array("name"),
           repo,
           new RepositoryIterator(
+            "/foo/bar",
             Array("id"),
             repo,
             Seq()

--- a/src/test/scala/tech/sourced/engine/iterator/ReferenceIteratorSpec.scala
+++ b/src/test/scala/tech/sourced/engine/iterator/ReferenceIteratorSpec.scala
@@ -66,6 +66,7 @@ class ReferenceIteratorSpec extends FlatSpec with BaseRootedRepoIterator {
         Array("repository_id", "name"),
         repo,
         new RepositoryIterator(
+          "/foo/bar",
           Array("id"),
           repo,
           Seq(EqualFilter(Attr("id", "repository"), "github.com/xiyou-linuxer/faq-xiyoulinux"))

--- a/src/test/scala/tech/sourced/engine/iterator/RepositoryIteratorSpec.scala
+++ b/src/test/scala/tech/sourced/engine/iterator/RepositoryIteratorSpec.scala
@@ -25,23 +25,30 @@ class RepositoryIteratorSpec extends FlatSpec with BaseRootedRepoIterator with B
 
   "RepositoryIterator" should "return data for all repositories into a siva file" in {
     testIterator(
-      new RepositoryIterator(Array("id", "urls", "is_fork"), _, Seq()), {
+      new RepositoryIterator(
+        "/foo/bar",
+        Array("id", "urls", "is_fork", "repository_path"),
+        _,
+        Seq()
+      ), {
         case (0, row) =>
           row.getString(0) should be("github.com/xiyou-linuxer/faq-xiyoulinux")
           row.getAs[Array[String]](1).length should be(3)
           row.getBoolean(2) should be(false)
+          row.getString(3) should be("/foo/bar")
         case (1, row) =>
           row.getString(0) should be("github.com/mawag/faq-xiyoulinux")
           row.getAs[Array[String]](1).length should be(3)
           row.getBoolean(2) should be(true)
+          row.getString(3) should be("/foo/bar")
         case (c, _) => fail(s"unexpected row number: $c")
-      }, total = 2, columnsCount = 3
+      }, total = 2, columnsCount = 4
     )
   }
 
   it should "return only specified columns" in {
     testIterator(
-      new RepositoryIterator(Array("id", "is_fork"), _, Seq()), {
+      new RepositoryIterator("/foo/bar", Array("id", "is_fork"), _, Seq()), {
         case (0, row) =>
           row.getString(0) should be("github.com/xiyou-linuxer/faq-xiyoulinux")
           row.getBoolean(1) should be(false)
@@ -56,6 +63,7 @@ class RepositoryIteratorSpec extends FlatSpec with BaseRootedRepoIterator with B
   it should "apply passed filters" in {
     testIterator(
       new RepositoryIterator(
+        "/foo/bar",
         Array("id", "is_fork"),
         _,
         Seq(EqualFilter(Attr("id", "repository"), "github.com/mawag/faq-xiyoulinux"))
@@ -83,7 +91,7 @@ class RepositoryIteratorSpec extends FlatSpec with BaseRootedRepoIterator with B
     val source = rdd.first()
     val repo = RepositoryProvider(tmpDir.toString).get(source)
 
-    val iter = new RepositoryIterator(Array("id"), repo, Seq())
+    val iter = new RepositoryIterator("/foo/bar", Array("id"), repo, Seq())
     val repos = iter.toList
 
     repos.length should be(2)


### PR DESCRIPTION
Depends on #227 

Before you ask, the `is_fork` column is being replaced because after a lot of debugging figured out that nullable boolean (not sure if not nullable boolean) is not handled well in the SQLite jdbc driver so fuck it, nullable integer it is, we have to un-transform arrays so we might as well transform `is_fork` when reading from the db.

EDIT: not-nullable boolean does not work either. `BIT` is not handled at all in the driver. FML.