### PR TITLE
Add default `repos_format`

### DIFF
--- a/python/sourced/engine/engine.py
+++ b/python/sourced/engine/engine.py
@@ -24,7 +24,7 @@ class Engine(object):
     :type skip_cleanup: bool
     """
 
-    def __init__(self, session, repos_path, repos_format, skip_cleanup=False):
+    def __init__(self, session, repos_path, repos_format='siva', skip_cleanup=False):
         self.session = session
         self.__jsparkSession = session._jsparkSession
         self.session.conf.set('spark.tech.sourced.engine.repositories.path', repos_path)


### PR DESCRIPTION
Let's make default `repos_format` to avoid sending this parameter always (in our case we use `siva` files almost always) + back compatibility with the previous version of `engine`.

+ it will make documentation in this class correct.
Right now it doesn't have `repos_format` (https://github.com/src-d/engine/blob/master/python/sourced/engine/engine.py#L12~#L14):
```
    >>> from sourced.engine import Engine
    >>> repos_df = Engine(sparkSession, "/path/to/my/repositories").repositories
    >>> repos_df.show()
```