### PR TITLE
[Optimizer] Throw an error if the query cannot be optimized

### DIFF
--- a/src/main/scala/tech/sourced/engine/rule/SquashGitRelationsJoin.scala
+++ b/src/main/scala/tech/sourced/engine/rule/SquashGitRelationsJoin.scala
@@ -1,5 +1,6 @@
 package tech.sourced.engine.rule
 
+import org.apache.spark.SparkException
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions._
@@ -119,8 +120,7 @@ private[rule] object GitOptimizer extends Logging {
         if (jm == j) {
           JoinData(valid = true, joinCondition = condition)
         } else {
-          logWarning(s"Join cannot be optimized. Invalid node: $jm")
-          JoinData()
+          throw new SparkException(s"Join cannot be optimized. Invalid node: $jm")
         }
       case Filter(cond, _) =>
         JoinData(Some(cond), valid = true)
@@ -135,8 +135,7 @@ private[rule] object GitOptimizer extends Logging {
           session = Some(session)
         )
       case other =>
-        logWarning(s"Join cannot be optimized. Invalid node: $other")
-        JoinData()
+        throw new SparkException(s"Join cannot be optimized. Invalid node: $other")
     }
 
     mergeJoinData(jd)

--- a/src/main/scala/tech/sourced/engine/rule/SquashMetadataRelationsJoin.scala
+++ b/src/main/scala/tech/sourced/engine/rule/SquashMetadataRelationsJoin.scala
@@ -1,5 +1,6 @@
 package tech.sourced.engine.rule
 
+import org.apache.spark.SparkException
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions._
@@ -115,8 +116,7 @@ private[rule] object MetadataOptimizer extends Logging {
         if (jm == j) {
           MetadataJoinData(valid = true, joinCondition = condition)
         } else {
-          logWarning(s"Join cannot be optimized. Invalid node: $jm")
-          MetadataJoinData()
+          throw new SparkException(s"Join cannot be optimized. Invalid node: $jm")
         }
       case Filter(cond, _) =>
         MetadataJoinData(Some(cond), valid = true)
@@ -140,8 +140,7 @@ private[rule] object MetadataOptimizer extends Logging {
           session = Some(session)
         )
       case other =>
-        logWarning(s"Join cannot be optimized. Invalid node: $other")
-        MetadataJoinData()
+        throw new SparkException(s"Join cannot be optimized. Invalid node: $other")
     }
 
     mergeMetadataJoinData(jd)

--- a/src/test/scala/tech/sourced/engine/BaseSourceSpec.scala
+++ b/src/test/scala/tech/sourced/engine/BaseSourceSpec.scala
@@ -1,5 +1,6 @@
 package tech.sourced.engine
 
+import org.apache.spark.SparkException
 import org.scalatest._
 
 class BaseSourceSpec(source: String)
@@ -29,6 +30,15 @@ class BaseSourceSpec(source: String)
     val commits = engine.getRepositories.filter("is_fork = false").getMaster.getCommits
     val df = commits.select("message").filter(commits("message").startsWith("a"))
     df.count should be(7)
+  }
+
+  it should "throw an error if the plan cannot be optimized" in {
+    val ex = intercept[SparkException] {
+      val refs = engine.getRepositories.limit(1).getReferences.limit(1)
+      refs.count
+    }
+
+    ex.getMessage should startWith("Join cannot be optimized. Invalid node: ")
   }
 
   it should "count all commits messages from all references that are not forks" in {


### PR DESCRIPTION
We cannot optimize any kind of query to push down them to the GitDatasource.

Because of that, some of the queries appears to be freezed due a lack of an optimized output.

To avoid that, now we throw an error if the query cannot be optimized to fetch repositories metadata.

Signed-off-by: Antonio Jesus Navarro Perez <antnavper@gmail.com>