### PR TITLE
Fixed language filtering

### DIFF
--- a/src/main/scala/tech/sourced/engine/rule/SquashGitRelationsJoin.scala
+++ b/src/main/scala/tech/sourced/engine/rule/SquashGitRelationsJoin.scala
@@ -31,7 +31,8 @@ object SquashGitRelationsJoin extends Rule[LogicalPlan] {
           val relation = LogicalRelation(
             GitRelation(
               session,
-              RelationOptimizer.attributesToSchema(attributes), joinConditions
+              RelationOptimizer.attributesToSchema(attributes),
+              joinConditions
             ),
             attributes,
             None
@@ -44,7 +45,7 @@ object SquashGitRelationsJoin extends Rule[LogicalPlan] {
 
           val filteredNode = filters match {
             case Some(filter) => Filter(filter, node)
-            case None => relation
+            case None => node
           }
 
           // If the projection is empty, just return the filter

--- a/src/test/scala/tech/sourced/engine/FilterUDFSpec.scala
+++ b/src/test/scala/tech/sourced/engine/FilterUDFSpec.scala
@@ -1,0 +1,30 @@
+package tech.sourced.engine
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class FilterUDFSpec extends FlatSpec with Matchers with BaseSivaSpec with BaseSparkSpec {
+
+  var engine: Engine = _
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    engine = Engine(ss, resourcePath, "siva")
+  }
+
+  "Filter by language" should "works properly" in {
+    val langDf = engine
+      .getRepositories
+      .getReferences
+      .getCommits
+      .getBlobs
+      .classifyLanguages
+
+    val filteredLang = langDf.select("repository_id", "path", "lang").where("lang='Python'")
+    filteredLang.count() should be(14)
+  }
+
+  override protected def afterAll(): Unit = {
+    super.afterAll()
+    engine = _: Engine
+  }
+}


### PR DESCRIPTION
Spark optimizes equality filters removing them and relaying on the `Scan GitRelation` to apply the filter as you can see in #277. Since our `UDF`s are generating data, the data to filter is not in the data source, so we must generate again the Filter node that spark is removing.

Now the `Physical Plan` generated is:
```scala
val langDf = engine
      .getRepositories
      .getReferences
      .getCommits
      .getBlobs
      .classifyLanguages

val filteredLang = langDf.select("repository_id", "path", "lang").where("lang='Python'")
filteredLang.explain(true)
```

Output:
```
== Physical Plan ==
*Project [repository_id#60, path#49, UDF(is_binary#63, path#49, content#62) AS lang#280]
+- *Filter (UDF(is_binary#63, path#49, content#62) = Python)
   +- *Scan GitRelation(org.apache.spark.sql.SparkSession@3b446d7,StructType(StructField(blob_id,StringType,false), StructField(commit_hash,StringType,false), StructField(repository_id,StringType,false), StructField(reference_name,StringType,false), StructField(content,BinaryType,true), StructField(is_binary,BooleanType,false), StructField(commit_hash,StringType,false), StructField(repository_id,StringType,false), StructField(reference_name,StringType,false), StructField(path,StringType,false), StructField(blob,StringType,false), StructField(repository_id,StringType,false), StructField(reference_name,StringType,false), StructField(index,IntegerType,false), StructField(hash,StringType,false), StructField(message,StringType,false), StructField(parents,ArrayType(StringType,false),true), StructField(parents_count,IntegerType,false), StructField(author_email,StringType,true), StructField(author_name,StringType,true), StructField(author_date,TimestampType,true), StructField(committer_email,StringType,true), StructField(committer_name,StringType,true), StructField(committer_date,TimestampType,true), StructField(repository_id,StringType,false), StructField(name,StringType,false), StructField(hash,StringType,false), StructField(id,StringType,false), StructField(urls,ArrayType(StringType,false),false), StructField(is_fork,BooleanType,true), StructField(repository_path,StringType,true)),Some((((UDF(is_binary#63, path#49, content#62) = Python) && (blob#50 = blob_id#58)) && ((commit_hash#46 = hash#21) && (((repository_id#10 = repository_id#18) && (reference_name#19 = name#11)) && (repository_id#10 = id#0))))),None) [repository_id#60,path#49,is_binary#63,content#62] ReadSchema: struct<repository_id:string,path:string,lang:string>```
```

On the other hand, note that if the `DataFrame` is persisted before applying the filter, it already worked properly before this PR because the data is already load from the source to the memory so the code below generates a different `Physical Plan`:
```scala
val langDf = engine
      .getRepositories
      .getReferences
      .getCommits
      .getBlobs
      .classifyLanguages
      .cache

val filteredLang = langDf.select("repository_id", "path", "lang").where("lang='Python'")
filteredLang.explain(true)
```

Output:
```
== Physical Plan ==
*Filter (isnotnull(lang#280) && (lang#280 = Python))
+- InMemoryTableScan [repository_id#60, path#49, lang#280], [isnotnull(lang#280), (lang#280 = Python)]
      +- InMemoryRelation [blob_id#58, commit_hash#59, repository_id#60, reference_name#61, content#62, is_binary#63, path#49, lang#280], true, 10000, StorageLevel(disk, memory, deserialized, 1 replicas)
            +- *Project [blob_id#58, commit_hash#59, repository_id#60, reference_name#61, content#62, is_binary#63, path#49, UDF(is_binary#63, path#49, content#62) AS lang#280]
               +- *Scan GitRelation(org.apache.spark.sql.SparkSession@12bb8943,StructType(StructField(blob_id,StringType,false), StructField(commit_hash,StringType,false), StructField(repository_id,StringType,false), StructField(reference_name,StringType,false), StructField(content,BinaryType,true), StructField(is_binary,BooleanType,false), StructField(commit_hash,StringType,false), StructField(repository_id,StringType,false), StructField(reference_name,StringType,false), StructField(path,StringType,false), StructField(blob,StringType,false), StructField(repository_id,StringType,false), StructField(reference_name,StringType,false), StructField(index,IntegerType,false), StructField(hash,StringType,false), StructField(message,StringType,false), StructField(parents,ArrayType(StringType,false),true), StructField(parents_count,IntegerType,false), StructField(author_email,StringType,true), StructField(author_name,StringType,true), StructField(author_date,TimestampType,true), StructField(committer_email,StringType,true), StructField(committer_name,StringType,true), StructField(committer_date,TimestampType,true), StructField(repository_id,StringType,false), StructField(name,StringType,false), StructField(hash,StringType,false), StructField(id,StringType,false), StructField(urls,ArrayType(StringType,false),false), StructField(is_fork,BooleanType,true), StructField(repository_path,StringType,true)),Some(((blob#50 = blob_id#58) && ((commit_hash#46 = hash#21) && (((repository_id#10 = repository_id#18) && (reference_name#19 = name#11)) && (repository_id#10 = id#0))))),None) [commit_hash#59,blob_id#58,content#62,path#49,reference_name#61,is_binary#63,repository_id#60] ReadSchema: struct<blob_id:string,commit_hash:string,repository_id:string,reference_name:string,content:binar...
```