### PR TITLE
check sources when testing whether a join condition is reundant as filter

### DIFF
--- a/src/main/scala/tech/sourced/engine/rule/SquashGitRelationsJoin.scala
+++ b/src/main/scala/tech/sourced/engine/rule/SquashGitRelationsJoin.scala
@@ -73,11 +73,11 @@ object SquashGitRelationsJoin extends Rule[LogicalPlan] {
   * @param valid              if the data is valid or not
   */
 private[rule] case class JoinData(filterExpression: Option[Expression] = None,
-                    joinCondition: Option[Expression] = None,
-                    projectExpressions: Seq[NamedExpression] = Nil,
-                    attributes: Seq[AttributeReference] = Nil,
-                    session: Option[SparkSession] = None,
-                    valid: Boolean = false)
+                                  joinCondition: Option[Expression] = None,
+                                  projectExpressions: Seq[NamedExpression] = Nil,
+                                  attributes: Seq[AttributeReference] = Nil,
+                                  session: Option[SparkSession] = None,
+                                  valid: Boolean = false)
 
 /**
   * Support methods for optimizing [[GitRelation]]s.


### PR DESCRIPTION
This adds a check that could not be performed before because not all `AttributeReference`s had a source. Now that they have it should be done to avoid marking as redundant filters that are not if the name of a field is used in more than one table, such as `hash` that's both in `references` and `commits`. It's not a very important thing, but better take care of it now than forget about it.  