### PR TITLE
add is_remote column to references table

### DIFF
--- a/_examples/pyspark/pyspark-shell-schemas.md
+++ b/_examples/pyspark/pyspark-shell-schemas.md
@@ -29,6 +29,7 @@ root
  |-- repository_id: string (nullable = false)
  |-- name: string (nullable = false)
  |-- hash: string (nullable = false)
+ |-- is_remote: boolean (nullable = false)
 '''
 
 engine.repositories.references.commits.printSchema()

--- a/_examples/scala/spark-shell-schemas.md
+++ b/_examples/scala/spark-shell-schemas.md
@@ -29,6 +29,7 @@ root
  |-- repository_id: string (nullable = false)
  |-- name: string (nullable = false)
  |-- hash: string (nullable = false)
+ |-- is_remote: boolean (nullable = false)
 */
 
 engine.getRepositories.getReferences.getCommits.printSchema

--- a/src/main/scala/tech/sourced/engine/Schema.scala
+++ b/src/main/scala/tech/sourced/engine/Schema.scala
@@ -29,6 +29,7 @@ private[engine] object Schema {
     StructField("repository_id", StringType, nullable = false) ::
       StructField("name", StringType, nullable = false) ::
       StructField("hash", StringType, nullable = false) ::
+      StructField("is_remote", BooleanType, nullable = false) ::
       Nil
   )
 

--- a/src/main/scala/tech/sourced/engine/iterator/ReferenceIterator.scala
+++ b/src/main/scala/tech/sourced/engine/iterator/ReferenceIterator.scala
@@ -33,7 +33,8 @@ class ReferenceIterator(finalColumns: Array[String],
     Map[String, Any](
       "repository_id" -> repoId,
       "name" -> refName,
-      "hash" -> ObjectId.toString(Option(ref.getPeeledObjectId).getOrElse(ref.getObjectId))
+      "hash" -> ObjectId.toString(Option(ref.getPeeledObjectId).getOrElse(ref.getObjectId)),
+      "is_remote" -> Option(repo.getRemoteName(ref.getName)).isDefined
     )
   }
 

--- a/src/test/scala/tech/sourced/engine/DefaultSourceSpec.scala
+++ b/src/test/scala/tech/sourced/engine/DefaultSourceSpec.scala
@@ -40,8 +40,18 @@ class DefaultSourceSpec extends BaseSourceSpec("DefaultSource") {
       .setDirectory(repoDir.toFile)
       .call()
 
-    val masters = Engine(ss, tmpPath.toString, "standard").getRepositories.getMaster.count()
-    masters should be(2)
+    val masters = Engine(ss, tmpPath.toString, "standard")
+      .getRepositories
+      .getMaster
+      .collect()
+      .sortBy(_.getAs[String]("repository_id"))
+
+    masters.length should be(2)
+    masters(0).getAs[String]("repository_id") should startWith("file")
+    masters(0).getAs[Boolean]("is_remote") should be(false)
+
+    masters(1).getAs[String]("repository_id") should startWith("github")
+    masters(1).getAs[Boolean]("is_remote") should be(true)
   }
 
   it should "match HEAD and not just refs/heads/HEAD" in {

--- a/src/test/scala/tech/sourced/engine/iterator/BaseChainableIterator.scala
+++ b/src/test/scala/tech/sourced/engine/iterator/BaseChainableIterator.scala
@@ -12,7 +12,7 @@ trait BaseChainableIterator extends Suite with BaseSparkSpec with BaseSivaSpec w
   lazy val rdd: RDD[RepositorySource] = prov.get(resourcePath, RepositoryRDDProvider.SivaFormat)
 
   lazy val source: RepositorySource = rdd.filter(source => source.pds.getPath()
-    .contains("fff7062de8474d10a67d417ccea87ba6f58ca81d.siva")).first()
+    .endsWith("fff7062de8474d10a67d417ccea87ba6f58ca81d.siva")).first()
   lazy val repo: Repository = RepositoryProvider("/tmp").get(source)
 
   def testIterator(iterator: (Repository) => Iterator[Row],


### PR DESCRIPTION
Adds `is_remote` column to `references` table so an user can identify if a reference was remote or not even after the rewrite from `refs/remotes/$REMOTE_NAME/$BRANCH` to `refs/heads/$BRANCH`.