### PR TITLE
make FilterUDFSpec faster filtering by only first ref commit

### DIFF
--- a/src/test/scala/tech/sourced/engine/FilterUDFSpec.scala
+++ b/src/test/scala/tech/sourced/engine/FilterUDFSpec.scala
@@ -11,16 +11,17 @@ class FilterUDFSpec extends FlatSpec with Matchers with BaseSivaSpec with BaseSp
     engine = Engine(ss, resourcePath, "siva")
   }
 
-  "Filter by language" should "works properly" in {
+  "Filter by language" should "work properly" in {
     val langDf = engine
       .getRepositories
       .getReferences
       .getCommits
+      .getFirstReferenceCommit
       .getBlobs
       .classifyLanguages
 
     val filteredLang = langDf.select("repository_id", "path", "lang").where("lang='Python'")
-    filteredLang.count() should be(14)
+    filteredLang.count() should be(6)
   }
 
   override protected def afterAll(): Unit = {


### PR DESCRIPTION
10s vs 1m19s
since all we need to check is that filter works, no need to not filter by first ref commit, which is faster.
It's not a very critical improvement but as we keep adding tests these little things count in how much our test suite takes to run