### PR TITLE
get only the last commit of a reference by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Then, you will be able to perform queries over the repositories:
 ```bash
 scala> engine.getRepositories.filter('id === "github.com/mawag/faq-xiyoulinux").
      | getReferences.filter('name === "refs/heads/HEAD").
-     | getCommits.filter('message.contains("Initial")).
+     | getAllReferenceCommits.filter('message.contains("Initial")).
      | select('repository_id, 'hash, 'message).
      | show
 

--- a/_examples/README.md
+++ b/_examples/README.md
@@ -16,6 +16,8 @@ Here you can find a list of annotated *source{d} Engine* examples:
 
 - [pyspark's shell querying UASTs with XPath](pyspark/pyspark-shell-xpath-query.md)
 
+- [pyspark's shell raw repositories](pyspark/pyspark-shell-raw-repositories.md)
+
 ### scala
 
 - [spark-shell basic example](scala/spark-shell-basic.md)
@@ -29,6 +31,8 @@ Here you can find a list of annotated *source{d} Engine* examples:
 - [spark-shell classifying languages and extracting UASTs](scala/spark-shell-lang-and-uast.md)
 
 - [spark-shell querying UASTs with XPath](scala/spark-shell-xpath-query.md)
+
+- [spark-shell raw repositories](scala/spark-shell-raw-repositories.md)
 
 ### jupyter notebooks
 

--- a/_examples/notebooks/Example.ipynb
+++ b/_examples/notebooks/Example.ipynb
@@ -55,7 +55,7 @@
    "outputs": [],
    "source": [
     "head_blobs = engine.repositories.filter(\"is_fork = false\").references\\\n",
-    ".head_ref.commits.first_reference_commit\\\n",
+    ".head_ref.commits\\\n",
     ".tree_entries.blobs\\\n",
     ".classify_languages()\\\n",
     ".filter(\"is_binary = false\")\\\n",
@@ -166,7 +166,7 @@
    "outputs": [],
    "source": [
     "idents = engine.repositories.filter(\"is_fork = false\").references\\\n",
-    ".head_ref.commits.first_reference_commit\\\n",
+    ".head_ref.commits\\\n",
     ".tree_entries.blobs\\\n",
     ".classify_languages()\\\n",
     ".extract_uasts()\\\n",

--- a/_examples/pyspark/pyspark-shell-schemas.md
+++ b/_examples/pyspark/pyspark-shell-schemas.md
@@ -33,6 +33,9 @@ root
 '''
 
 engine.repositories.references.commits.printSchema()
+'''
+Also: engine.repositories.references.all_reference_commits.printSchema()
+'''
 ''' Output:
 root
  |-- repository_id: string (nullable = false)

--- a/_examples/scala/spark-shell-schemas.md
+++ b/_examples/scala/spark-shell-schemas.md
@@ -33,6 +33,7 @@ root
 */
 
 engine.getRepositories.getReferences.getCommits.printSchema
+/* also engine.getRepositories.getReferences.getAllReferenceCommits.printSchema */
 /* Output:
 root
  |-- repository_id: string (nullable = false)

--- a/examples/notebooks/Example.ipynb
+++ b/examples/notebooks/Example.ipynb
@@ -55,7 +55,7 @@
    "outputs": [],
    "source": [
     "head_blobs = engine.repositories.filter(\"is_fork = false\").references\\\n",
-    ".head_ref.commits.first_reference_commit\\\n",
+    ".head_ref.commits\\\n",
     ".tree_entries.blobs\\\n",
     ".classify_languages()\\\n",
     ".filter(\"is_binary = false\")\\\n",
@@ -166,7 +166,7 @@
    "outputs": [],
    "source": [
     "idents = engine.repositories.filter(\"is_fork = false\").references\\\n",
-    ".head_ref.commits.first_reference_commit\\\n",
+    ".head_ref.commits\\\n",
     ".tree_entries.blobs\\\n",
     ".classify_languages()\\\n",
     ".extract_uasts()\\\n",

--- a/python/sourced/examples/repo_files.py
+++ b/python/sourced/examples/repo_files.py
@@ -9,7 +9,7 @@ def main():
     repos_path = os.path.join(file_path, '..', '..', '..', 'src', 'test', 'resources', 'siva-files')
     session = SparkSession.builder.appName("test").master('local[*]').getOrCreate()
     engine = Engine(session, repos_path, "siva")
-    rows = engine.repositories.references.head_ref.commits.first_reference_commit\
+    rows = engine.repositories.references.head_ref.commits\
         .tree_entries.select('path').collect()
 
     files = [r['path'] for r in rows]

--- a/python/sourced/examples/uasts.py
+++ b/python/sourced/examples/uasts.py
@@ -9,7 +9,7 @@ def main():
     engine = Engine(session, repos_path, "siva")
     engine.repositories.references\
         .filter('name = "refs/heads/develop"')\
-        .commits.first_reference_commit.tree_entries.blobs\
+        .commits.tree_entries.blobs\
         .classify_languages()\
         .filter('lang = "Ruby"')\
         .extract_uasts()\

--- a/python/test/test_engine.py
+++ b/python/test/test_engine.py
@@ -73,8 +73,8 @@ class EngineTestCase(BaseTestCase):
         self.assertEqual(len(df.collect()), 2)
 
 
-    def test_commits(self):
-        df = self.engine.repositories.references.commits
+    def test_all_commits(self):
+        df = self.engine.repositories.references.all_reference_commits
         repo_commits = df.groupBy(df.repository_id)\
             .count()\
             .collect()
@@ -85,14 +85,14 @@ class EngineTestCase(BaseTestCase):
                              REPOSITORY_COMMITS[repo.repository_id])
 
 
-    def test_commits_first(self):
+    def test_commits(self):
         df = self.engine.repositories.references.filter("name not like 'refs/tags/%'")
         repo_refs = df.groupBy(df.repository_id).count().collect()
         repos = {}
         for repo in repo_refs:
             repos[repo["repository_id"]] = repo["count"]
 
-        df = self.engine.repositories.references.commits.first_reference_commit
+        df = self.engine.repositories.references.commits
         repo_commits = df.groupBy(df.repository_id) \
             .count() \
             .collect()
@@ -103,7 +103,7 @@ class EngineTestCase(BaseTestCase):
 
 
     def test_tree_entries(self):
-        df = self.engine.repositories.references.commits.tree_entries
+        df = self.engine.repositories.references.all_reference_commits.tree_entries
         self.assertEqual(df.count(), 304362)
         entry = df.sort(df.blob).limit(1).first()
         self.assertEqual(entry.blob, '0020a823b6e5b06c9adb7def76ccd7ed098a06b8')
@@ -111,7 +111,7 @@ class EngineTestCase(BaseTestCase):
 
 
     def test_blobs(self):
-        df = self.engine.repositories.references.commits\
+        df = self.engine.repositories.references.all_reference_commits\
             .tree_entries.blobs.drop("repository_id", "reference_name").distinct()
         self.assertEqual(df.count(), 91944)
         file = df.sort(df.blob_id).limit(1).first()
@@ -120,7 +120,7 @@ class EngineTestCase(BaseTestCase):
 
 
     def test_classify_languages(self):
-        df = self.engine.repositories.references.commits.tree_entries.blobs
+        df = self.engine.repositories.references.all_reference_commits.tree_entries.blobs
         row = df.sort(df.blob_id).limit(1).classify_languages().first()
         self.assertEqual(row.blob_id, "0020a823b6e5b06c9adb7def76ccd7ed098a06b8")
         self.assertEqual(row.path, 'spec/database_spec.rb')
@@ -128,7 +128,7 @@ class EngineTestCase(BaseTestCase):
 
 
     def test_extract_uasts(self):
-        df = self.engine.repositories.references.commits.tree_entries.blobs
+        df = self.engine.repositories.references.all_reference_commits.tree_entries.blobs
         row = df.sort(df.blob_id).limit(1).classify_languages()\
             .extract_uasts().first()
         self.assertEqual(row.blob_id, "0020a823b6e5b06c9adb7def76ccd7ed098a06b8")
@@ -136,7 +136,7 @@ class EngineTestCase(BaseTestCase):
         self.assertEqual(row.lang, "Ruby")
         self.assertEqual(row.uast, [])
 
-        df = self.engine.repositories.references.commits.tree_entries.blobs
+        df = self.engine.repositories.references.all_reference_commits.tree_entries.blobs
         row = df.sort(df.blob_id).limit(1).extract_uasts().first()
         self.assertEqual(row.blob_id, "0020a823b6e5b06c9adb7def76ccd7ed098a06b8")
         self.assertEqual(row.path, 'spec/database_spec.rb')
@@ -144,7 +144,7 @@ class EngineTestCase(BaseTestCase):
 
 
     def test_engine_blobs(self):
-        rows = self.engine.repositories.references.head_ref.commits.sort('hash').limit(10).collect()
+        rows = self.engine.repositories.references.head_ref.all_reference_commits.sort('hash').limit(10).collect()
         repos = []
         hashes = []
         for row in rows:

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -84,7 +84,7 @@
  </check>
  <check level="error" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="true">
   <parameters>
-   <parameter name="maxLength"><![CDATA[80]]></parameter>
+   <parameter name="maxLength"><![CDATA[150]]></parameter>
   </parameters>
  </check>
  <check level="error" class="org.scalastyle.scalariform.MethodNamesChecker" enabled="true">

--- a/src/main/scala/tech/sourced/engine/Engine.scala
+++ b/src/main/scala/tech/sourced/engine/Engine.scala
@@ -154,10 +154,8 @@ class Engine(val session: SparkSession,
     }
 
     var commitsDf = refsDf.getCommits
-    commitsDf = if (commitHashes.nonEmpty) {
-      commitsDf.filter(commitsDf("hash").isin(commitHashes: _*))
-    } else {
-      commitsDf.getFirstReferenceCommit
+    if (commitHashes.nonEmpty) {
+      commitsDf = commitsDf.getAllReferenceCommits.filter(commitsDf("hash").isin(commitHashes: _*))
     }
 
     commitsDf.getTreeEntries.getBlobs
@@ -262,7 +260,7 @@ class Engine(val session: SparkSession,
 
     val repositoriesDf = getDataSource(RepositoriesTable, session)
     val referencesDf = repositoriesDf.getReferences
-    val commitsDf = referencesDf.getCommits
+    val commitsDf = referencesDf.getAllReferenceCommits
     val treeEntriesDf = commitsDf.getTreeEntries
 
     import MetadataDataFrameCompat._

--- a/src/main/scala/tech/sourced/engine/QueryBuilder.scala
+++ b/src/main/scala/tech/sourced/engine/QueryBuilder.scala
@@ -188,7 +188,8 @@ private[engine] object QueryBuilder {
         // If we can make sure compileFilter supports all filters, we can remove this check.
         val or = Seq(f1, f2).flatMap(compileFilter)
         if (or.size == 2) {
-          or.map(p => s"($p)").mkString(" OR ")
+          val clause = or.map(p => s"($p)").mkString(" OR ")
+          s"($clause)"
         } else {
           null
         }

--- a/src/main/scala/tech/sourced/engine/Sources.scala
+++ b/src/main/scala/tech/sourced/engine/Sources.scala
@@ -49,10 +49,9 @@ object Sources {
     }
 
   def getFiltersBySource(filters: Seq[Expression]): Map[String, Seq[CompiledFilter]] =
-    filters.map(Filter.compile)
-      .flatMap(_.filters)
+    filters.flatMap(Filter.compile)
       .map(e => (e.sources.distinct, e))
-      .filter(_._1.length == 1)
+      .filter(_._1.lengthCompare(1) == 0)
       .groupBy(_._1)
       .map { case (k, v) => (k.head, v.map(_._2)) }
 

--- a/src/test/scala/tech/sourced/engine/EngineSpec.scala
+++ b/src/test/scala/tech/sourced/engine/EngineSpec.scala
@@ -34,14 +34,14 @@ class EngineSpec extends FlatSpec with Matchers with BaseSivaSpec with BaseSpark
     val properties = new Properties()
     properties.put("driver", "org.sqlite.JDBC")
 
-    val reposDf = getDataSource(RepositoriesTable, ss)
-    val refsDf = getDataSource(ReferencesTable, ss)
-    val repoHasCommitsDf = getDataSource(CommitsTable, ss)
+    val reposDf = engine.getRepositories
+    val refsDf = reposDf.getReferences
+    val repoHasCommitsDf = refsDf.getAllReferenceCommits
       .select("reference_name", "repository_id", "hash", "index")
-    val commitsDf = getDataSource(CommitsTable, ss)
+    val commitsDf = refsDf.getAllReferenceCommits
       .drop("index", "reference_name", "repository_id")
       .distinct()
-    val treeEntriesDf = getDataSource(TreeEntriesTable, ss)
+    val treeEntriesDf = refsDf.getAllReferenceCommits.getTreeEntries
       .drop("reference_name", "repository_id")
       .distinct()
 

--- a/src/test/scala/tech/sourced/engine/FilterUDFSpec.scala
+++ b/src/test/scala/tech/sourced/engine/FilterUDFSpec.scala
@@ -16,7 +16,6 @@ class FilterUDFSpec extends FlatSpec with Matchers with BaseSivaSpec with BaseSp
       .getRepositories
       .getReferences
       .getCommits
-      .getFirstReferenceCommit
       .getBlobs
       .classifyLanguages
 

--- a/src/test/scala/tech/sourced/engine/QueryBuilderSpec.scala
+++ b/src/test/scala/tech/sourced/engine/QueryBuilderSpec.scala
@@ -59,7 +59,7 @@ class QueryBuilderSpec extends FlatSpec with Matchers {
       (Or(EqualTo(attr("foo", "bar"), Literal(1, IntegerType)),
         EqualTo(attr("foo", "bar"), Literal(2, IntegerType))
       ),
-        s"($col = 1) OR ($col = 2)"),
+        s"(($col = 1) OR ($col = 2))"),
       (And(EqualTo(attr("foo", "bar"), Literal(1, IntegerType)),
         EqualTo(attr("foo", "bar"), Literal(2, IntegerType))
       ),

--- a/src/test/scala/tech/sourced/engine/iterator/BlobIteratorSpec.scala
+++ b/src/test/scala/tech/sourced/engine/iterator/BlobIteratorSpec.scala
@@ -3,7 +3,7 @@ package tech.sourced.engine.iterator
 import java.nio.charset.StandardCharsets
 
 import org.scalatest.FlatSpec
-import tech.sourced.engine.util.{Attr, CompiledFilter, EqualFilter, InFilter}
+import tech.sourced.engine.util._
 
 class BlobIteratorSpec extends FlatSpec with BaseChainableIterator {
 
@@ -16,120 +16,129 @@ class BlobIteratorSpec extends FlatSpec with BaseChainableIterator {
     "is_binary"
   )
 
+  private val allCommitsFilter = NotFilter(EqualFilter(Attr("index", "commits"), -1))
+
   "BlobIterator" should "return all blobs for files at every commit of all refs in repository" in {
-    testIterator(
+    testIterator(repo =>
       new BlobIterator(
-        columns, _, null, Seq()), {
-        case (0, row) =>
-          row.getString(0) should be("733c072369ca77331f392c40da7404c85c36542c")
-          row.getString(1) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
-          row.getString(2) should be("github.com/xiyou-linuxer/faq-xiyoulinux")
-          row.getString(3) should be("refs/heads/HEAD")
-          new String(row.getAs[Array[Byte]](4), StandardCharsets.UTF_8)
-            .should(startWith("                    GNU GENERAL PUBLIC LICENSE"))
-          row.getBoolean(5) should be(false)
-        case (1, row) =>
-          row.getString(0) should be("2d2ad68c14c51e62595125b86b464427f6bf2126")
-          row.getString(1) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
-          row.getString(2) should be("github.com/xiyou-linuxer/faq-xiyoulinux")
-          row.getString(3) should be("refs/heads/HEAD")
-          new String(row.getAs[Array[Byte]](4), StandardCharsets.UTF_8)
-            .should(startWith("# faq-xiyoulinux"))
-          row.getBoolean(5) should be(false)
-        case (2, row) =>
-          row.getString(0) should be("733c072369ca77331f392c40da7404c85c36542c")
-          row.getString(1) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
-          row.getString(2) should be("github.com/mawag/faq-xiyoulinux")
-          row.getString(3) should be("refs/heads/HEAD")
-          new String(row.getAs[Array[Byte]](4), StandardCharsets.UTF_8)
-            .should(startWith("                    GNU GENERAL PUBLIC LICENSE"))
-          row.getBoolean(5) should be(false)
-        case _ =>
-      }, total = 22187, columnsCount = columns.length
+        columns, repo, null, Seq(allCommitsFilter)), {
+      case (0, row) =>
+        row.getString(0) should be("733c072369ca77331f392c40da7404c85c36542c")
+        row.getString(1) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
+        row.getString(2) should be("github.com/xiyou-linuxer/faq-xiyoulinux")
+        row.getString(3) should be("refs/heads/HEAD")
+        new String(row.getAs[Array[Byte]](4), StandardCharsets.UTF_8)
+          .should(startWith("                    GNU GENERAL PUBLIC LICENSE"))
+        row.getBoolean(5) should be(false)
+      case (1, row) =>
+        row.getString(0) should be("2d2ad68c14c51e62595125b86b464427f6bf2126")
+        row.getString(1) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
+        row.getString(2) should be("github.com/xiyou-linuxer/faq-xiyoulinux")
+        row.getString(3) should be("refs/heads/HEAD")
+        new String(row.getAs[Array[Byte]](4), StandardCharsets.UTF_8)
+          .should(startWith("# faq-xiyoulinux"))
+        row.getBoolean(5) should be(false)
+      case (2, row) =>
+        row.getString(0) should be("733c072369ca77331f392c40da7404c85c36542c")
+        row.getString(1) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
+        row.getString(2) should be("github.com/mawag/faq-xiyoulinux")
+        row.getString(3) should be("refs/heads/HEAD")
+        new String(row.getAs[Array[Byte]](4), StandardCharsets.UTF_8)
+          .should(startWith("                    GNU GENERAL PUBLIC LICENSE"))
+        row.getBoolean(5) should be(false)
+      case _ =>
+    }, total = 22187, columnsCount = columns.length
       // NOTE: it differs from the number of tree entries in GitTreeEntryIteratorSpec because
       // Blob Objects can be missing
     )
   }
 
   it should "filter refs and return only blobs in HEAD of the given ref" in {
-    val refFilters = Seq(EqualFilter(
-      Attr("reference_name", "commits"),
-      "refs/heads/HEAD")
+    val filters = Seq(
+      EqualFilter(
+        Attr("reference_name", "commits"),
+        "refs/heads/HEAD"
+      ),
+      allCommitsFilter
     )
 
-    testIterator(
+    testIterator(repo =>
       new BlobIterator(
-        columns, _, null, refFilters), {
-        case (0, row) =>
-          row.getString(0) should be("733c072369ca77331f392c40da7404c85c36542c")
-          row.getString(1) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
-          row.getString(2) should be("github.com/xiyou-linuxer/faq-xiyoulinux")
-          row.getString(3) should be("refs/heads/HEAD")
-          new String(row.getAs[Array[Byte]](4), StandardCharsets.UTF_8)
-            .should(startWith("                    GNU GENERAL PUBLIC LICENSE"))
-          row.getBoolean(5) should be(false)
-        case (1, row) =>
-          row.getString(0) should be("2d2ad68c14c51e62595125b86b464427f6bf2126")
-          row.getString(1) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
-          row.getString(2) should be("github.com/xiyou-linuxer/faq-xiyoulinux")
-          row.getString(3) should be("refs/heads/HEAD")
-          new String(row.getAs[Array[Byte]](4), StandardCharsets.UTF_8)
-            .should(startWith("# faq-xiyoulinux"))
-          row.getBoolean(5) should be(false)
-        case (2, row) =>
-          row.getString(0) should be("733c072369ca77331f392c40da7404c85c36542c")
-          row.getString(1) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
-          row.getString(2) should be("github.com/mawag/faq-xiyoulinux")
-          row.getString(3) should be("refs/heads/HEAD")
-          new String(row.getAs[Array[Byte]](4), StandardCharsets.UTF_8)
-            .should(startWith("                    GNU GENERAL PUBLIC LICENSE"))
-          row.getBoolean(5) should be(false)
-        case (_, row) =>
-          row.getString(3) should be("refs/heads/HEAD")
-      }, total = 4, columnsCount = columns.length
+        columns, repo, null, filters), {
+      case (0, row) =>
+        row.getString(0) should be("733c072369ca77331f392c40da7404c85c36542c")
+        row.getString(1) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
+        row.getString(2) should be("github.com/xiyou-linuxer/faq-xiyoulinux")
+        row.getString(3) should be("refs/heads/HEAD")
+        new String(row.getAs[Array[Byte]](4), StandardCharsets.UTF_8)
+          .should(startWith("                    GNU GENERAL PUBLIC LICENSE"))
+        row.getBoolean(5) should be(false)
+      case (1, row) =>
+        row.getString(0) should be("2d2ad68c14c51e62595125b86b464427f6bf2126")
+        row.getString(1) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
+        row.getString(2) should be("github.com/xiyou-linuxer/faq-xiyoulinux")
+        row.getString(3) should be("refs/heads/HEAD")
+        new String(row.getAs[Array[Byte]](4), StandardCharsets.UTF_8)
+          .should(startWith("# faq-xiyoulinux"))
+        row.getBoolean(5) should be(false)
+      case (2, row) =>
+        row.getString(0) should be("733c072369ca77331f392c40da7404c85c36542c")
+        row.getString(1) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
+        row.getString(2) should be("github.com/mawag/faq-xiyoulinux")
+        row.getString(3) should be("refs/heads/HEAD")
+        new String(row.getAs[Array[Byte]](4), StandardCharsets.UTF_8)
+          .should(startWith("                    GNU GENERAL PUBLIC LICENSE"))
+        row.getBoolean(5) should be(false)
+      case (_, row) =>
+        row.getString(3) should be("refs/heads/HEAD")
+    }, total = 4, columnsCount = columns.length
     )
 
   }
 
   it should "filter repositories if given" in {
-    val refFilters = Seq(EqualFilter(
-      Attr("repository_id", "references"),
-      "github.com/mawag/faq-xiyoulinux"
-    ))
-
-    testIterator(
-      new BlobIterator(
-        columns, _, null, refFilters), {
-        case (0, row) =>
-          row.getString(0) should be("733c072369ca77331f392c40da7404c85c36542c")
-          row.getString(1) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
-          row.getString(2) should be("github.com/mawag/faq-xiyoulinux")
-          row.getString(3) should be("refs/heads/HEAD")
-          new String(row.getAs[Array[Byte]](4), StandardCharsets.UTF_8)
-            .should(startWith("                    GNU GENERAL PUBLIC LICENSE"))
-          row.getBoolean(5) should be(false)
-        case (1, row) =>
-          row.getString(0) should be("2d2ad68c14c51e62595125b86b464427f6bf2126")
-          row.getString(1) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
-          row.getString(2) should be("github.com/mawag/faq-xiyoulinux")
-          row.getString(3) should be("refs/heads/HEAD")
-          new String(row.getAs[Array[Byte]](4), StandardCharsets.UTF_8)
-            .should(startWith("# faq-xiyoulinux"))
-          row.getBoolean(5) should be(false)
-        case (_, row) =>
-          row.getString(2) should be("github.com/mawag/faq-xiyoulinux")
-      }, total = 2139, columnsCount = columns.length
-    )
-  }
-
-  it should "filter commits and return only blobs of the given commit" in {
-    val refFilters = Seq(EqualFilter(
-      Attr("commit_hash", "commits"), "fff7062de8474d10a67d417ccea87ba6f58ca81d")
+    val filters = Seq(
+      EqualFilter(
+        Attr("repository_id", "references"),
+        "github.com/mawag/faq-xiyoulinux"
+      ),
+      allCommitsFilter
     )
 
     testIterator(repo =>
       new BlobIterator(
-        columns, repo, null, refFilters), {
+        columns, repo, null, filters), {
+      case (0, row) =>
+        row.getString(0) should be("733c072369ca77331f392c40da7404c85c36542c")
+        row.getString(1) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
+        row.getString(2) should be("github.com/mawag/faq-xiyoulinux")
+        row.getString(3) should be("refs/heads/HEAD")
+        new String(row.getAs[Array[Byte]](4), StandardCharsets.UTF_8)
+          .should(startWith("                    GNU GENERAL PUBLIC LICENSE"))
+        row.getBoolean(5) should be(false)
+      case (1, row) =>
+        row.getString(0) should be("2d2ad68c14c51e62595125b86b464427f6bf2126")
+        row.getString(1) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
+        row.getString(2) should be("github.com/mawag/faq-xiyoulinux")
+        row.getString(3) should be("refs/heads/HEAD")
+        new String(row.getAs[Array[Byte]](4), StandardCharsets.UTF_8)
+          .should(startWith("# faq-xiyoulinux"))
+        row.getBoolean(5) should be(false)
+      case (_, row) =>
+        row.getString(2) should be("github.com/mawag/faq-xiyoulinux")
+    }, total = 2139, columnsCount = columns.length
+    )
+  }
+
+  it should "filter commits and return only blobs of the given commit" in {
+    val filters = Seq(EqualFilter(
+      Attr("commit_hash", "commits"), "fff7062de8474d10a67d417ccea87ba6f58ca81d"),
+      allCommitsFilter
+    )
+
+    testIterator(repo =>
+      new BlobIterator(
+        columns, repo, null, filters), {
       case (_, row) =>
         row.getString(1) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
     }, total = 86, columnsCount = columns.length
@@ -142,7 +151,8 @@ class BlobIteratorSpec extends FlatSpec with BaseChainableIterator {
       "fff7062de8474d10a67d417ccea87ba6f58ca81d"
     )
     val filters = Array[CompiledFilter](
-      InFilter(Attr("hash", "commits"), commits)
+      InFilter(Attr("hash", "commits"), commits),
+      allCommitsFilter
     )
 
     testIterator(repo =>
@@ -199,7 +209,7 @@ class BlobIteratorSpec extends FlatSpec with BaseChainableIterator {
               ),
               Seq()
             ),
-            Seq(InFilter(Attr("hash", "commits"), commits))
+            Seq(InFilter(Attr("hash", "commits"), commits), allCommitsFilter)
           ),
           Seq()
         ),
@@ -214,7 +224,10 @@ class BlobIteratorSpec extends FlatSpec with BaseChainableIterator {
   }
 
   it should "not fail with other, un-supported filters" in {
-    val filters = Array[CompiledFilter](EqualFilter(Attr("message", "commits"), "README"))
+    val filters = Array[CompiledFilter](
+      EqualFilter(Attr("message", "commits"), "README"),
+      allCommitsFilter
+    )
 
     testIterator(repo =>
       new BlobIterator(columns, repo, null, filters)

--- a/src/test/scala/tech/sourced/engine/iterator/CommitIteratorSpec.scala
+++ b/src/test/scala/tech/sourced/engine/iterator/CommitIteratorSpec.scala
@@ -3,7 +3,7 @@ package tech.sourced.engine.iterator
 import java.sql.Timestamp
 
 import org.scalatest.FlatSpec
-import tech.sourced.engine.util.{Attr, EqualFilter, InFilter}
+import tech.sourced.engine.util.{Attr, EqualFilter, InFilter, NotFilter}
 
 class CommitIteratorSpec extends FlatSpec with BaseChainableIterator {
 
@@ -23,10 +23,12 @@ class CommitIteratorSpec extends FlatSpec with BaseChainableIterator {
     "committer_date"
   )
 
+  private val allCommitsFilter = NotFilter(EqualFilter(Attr("index", "commits"), -1))
+
   "CommitIterator" should "return all commits from all repositories into a siva file" in {
     testIterator(
       new CommitIterator(
-        cols, _, null, Seq()), {
+        cols, _, null, Seq(allCommitsFilter)), {
         case (0, row) =>
           row.getString(0) should be("github.com/xiyou-linuxer/faq-xiyoulinux")
           row.getString(1) should be("refs/heads/HEAD")
@@ -85,7 +87,7 @@ class CommitIteratorSpec extends FlatSpec with BaseChainableIterator {
         Array(
           "repository_id",
           "parents"
-        ), _, null, Seq()), {
+        ), _, null, Seq(allCommitsFilter)), {
         case (0, row) =>
           row.getString(0) should be("github.com/xiyou-linuxer/faq-xiyoulinux")
           row.getAs[Array[String]](1) should be(Array())
@@ -118,7 +120,7 @@ class CommitIteratorSpec extends FlatSpec with BaseChainableIterator {
         ),
         _,
         null,
-        Seq(InFilter(Attr("hash", "commits"), commits))
+        Seq(InFilter(Attr("hash", "commits"), commits), allCommitsFilter)
       ), {
         case (0, row) =>
           row.getString(0) should be("github.com/xiyou-linuxer/faq-xiyoulinux")
@@ -160,7 +162,7 @@ class CommitIteratorSpec extends FlatSpec with BaseChainableIterator {
             "refs/heads/master", "refs/heads/develop"
           )))
         ),
-        Seq()
+        Seq(allCommitsFilter)
       ), {
       case (0, row) =>
         row.getString(0) should be("github.com/xiyou-linuxer/faq-xiyoulinux")

--- a/src/test/scala/tech/sourced/engine/iterator/GitTreeEntryIteratorSpec.scala
+++ b/src/test/scala/tech/sourced/engine/iterator/GitTreeEntryIteratorSpec.scala
@@ -1,7 +1,7 @@
 package tech.sourced.engine.iterator
 
 import org.scalatest.FlatSpec
-import tech.sourced.engine.util.{Attr, EqualFilter}
+import tech.sourced.engine.util.{Attr, EqualFilter, NotFilter}
 
 class GitTreeEntryIteratorSpec extends FlatSpec with BaseChainableIterator {
 
@@ -13,11 +13,13 @@ class GitTreeEntryIteratorSpec extends FlatSpec with BaseChainableIterator {
     "blob"
   )
 
+  private val allCommitsFilter = NotFilter(EqualFilter(Attr("index", "commits"), -1))
+
   "GitTreeEntryIterator" should "return all tree entries from all commits " +
     "from all repositories into a siva file" in {
-    testIterator(
+    testIterator(repo =>
       new GitTreeEntryIterator(
-        cols, _, null, Seq()), {
+        cols, repo, new CommitIterator(cols, repo, null, Seq(allCommitsFilter)), Seq()), {
         case (0, row) =>
           row.getString(0) should be("fff7062de8474d10a67d417ccea87ba6f58ca81d")
           row.getString(1) should be("github.com/xiyou-linuxer/faq-xiyoulinux")
@@ -53,9 +55,9 @@ class GitTreeEntryIteratorSpec extends FlatSpec with BaseChainableIterator {
       "README.md")
     )
 
-    testIterator(
+    testIterator(repo =>
       new GitTreeEntryIterator(
-        cols, _, null, filters), {
+        cols, repo, new CommitIterator(cols, repo, null, Seq(allCommitsFilter)), filters), {
         case (_, r) =>
           r.getString(3) should be("README.md")
       }, total = 1062, columnsCount = cols.length
@@ -68,9 +70,9 @@ class GitTreeEntryIteratorSpec extends FlatSpec with BaseChainableIterator {
       "733c072369ca77331f392c40da7404c85c36542c")
     )
 
-    testIterator(
+    testIterator(repo =>
       new GitTreeEntryIterator(
-        cols, _, null, filters), {
+        cols, repo, new CommitIterator(cols, repo, null, Seq(allCommitsFilter)), filters), {
         case (_, r) =>
           r.getString(4) should be("733c072369ca77331f392c40da7404c85c36542c")
       }, total = 1062, columnsCount = cols.length
@@ -80,7 +82,8 @@ class GitTreeEntryIteratorSpec extends FlatSpec with BaseChainableIterator {
   it should "work when it's chained" in {
     val filters = Seq(EqualFilter(
       Attr("hash", "commits"),
-      "fff7062de8474d10a67d417ccea87ba6f58ca81d")
+      "fff7062de8474d10a67d417ccea87ba6f58ca81d"),
+      allCommitsFilter
     )
 
     testIterator(repo =>
@@ -109,9 +112,9 @@ class GitTreeEntryIteratorSpec extends FlatSpec with BaseChainableIterator {
       "fff7062de8474d10a67d417ccea87ba6f58ca81d")
     )
 
-    testIterator(
+    testIterator(repo =>
       new GitTreeEntryIterator(
-        cols, _, null, filters), {
+        cols, repo, new CommitIterator(cols, repo, null, Seq(allCommitsFilter)), filters), {
         case (i, r) if i % 2 == 0 =>
           r.getString(4) should be("733c072369ca77331f392c40da7404c85c36542c")
           r.getString(3) should be("LICENSE")

--- a/src/test/scala/tech/sourced/engine/util/FilterSpec.scala
+++ b/src/test/scala/tech/sourced/engine/util/FilterSpec.scala
@@ -8,92 +8,69 @@ class FilterSpec extends FlatSpec with Matchers {
   "CompiledFilters" should "filter properly depending of his type" in {
     val eq = EqualFilter(Attr("test", ""), "a")
 
-    eq.matchingCases should be(Map("test" -> Seq("a")))
-
-    eq.eval(Map("test" -> "a")) should be(Some(true))
-    eq.eval(Map("test" -> "a", "test3" -> "a")) should be(Some(true))
-    eq.eval(Map("test" -> "b")) should be(Some(false))
-    eq.eval(Map("test2" -> "b")) should be(None)
-
-    val or = OrFilter(
-      EqualFilter(Attr("test", ""), "a"),
-      EqualFilter(Attr("test", ""), "b")
-    )
-
-    or.matchingCases should be(Map("test" -> Seq("a", "b")))
-
-    or.eval(Map("test" -> "a")) should be(Some(true))
-    or.eval(Map("test" -> "b")) should be(Some(true))
-    or.eval(Map("test" -> "c")) should be(Some(false))
-    or.eval(Map("test2" -> "b")) should be(None)
-
-    val orTwo = OrFilter(EqualFilter(Attr("test", ""), "a"), EqualFilter(Attr("test2", ""), "b"))
-
-    orTwo.matchingCases should be(Map("test" -> Seq("a"), "test2" -> Seq("b")))
-
-    orTwo.eval(Map("test" -> "a")) should be(Some(true))
-    orTwo.eval(Map("test" -> "b")) should be(Some(false))
-    orTwo.eval(Map("test" -> "c")) should be(Some(false))
-    orTwo.eval(Map("test2" -> "b")) should be(Some(true))
-    orTwo.eval(Map("test3" -> "b")) should be(None)
-
-    val and = AndFilter(EqualFilter(Attr("test", ""), "a"), EqualFilter(Attr("test2", ""), "b"))
-
-    and.matchingCases should be(Map("test" -> Seq("a"), "test2" -> Seq("b")))
-
-    and.eval(Map("test" -> "a", "test2" -> "b")) should be(Some(true))
-    and.eval(Map("test" -> "a", "test2" -> "b", "test3" -> "c")) should be(Some(true))
-    and.eval(Map("test" -> "a")) should be(Some(false))
-    and.eval(Map("test" -> "c")) should be(Some(false))
-    and.eval(Map("test2" -> "b")) should be(Some(false))
-    and.eval(Map("test3" -> "b")) should be(None)
+    eq.eval("a") should be(true)
+    eq.eval("b") should be(false)
 
     val notEq = NotFilter(EqualFilter(Attr("test", ""), "a"))
 
-    notEq.matchingCases should be(Map())
-
-    notEq.eval(Map("test" -> "a")) should be(Some(false))
-    notEq.eval(Map("test" -> "a", "test2" -> "a")) should be(Some(false))
-    notEq.eval(Map("test" -> "b", "test2" -> "a")) should be(Some(true))
-    notEq.eval(Map("test2" -> "a")) should be(None)
+    notEq.eval("a") should be(false)
+    notEq.eval("b") should be(true)
 
     val in = InFilter(Attr("test", ""), Array("a", "b", "c"))
 
-    in.matchingCases should be(Map("test" -> Seq("a", "b", "c")))
+    in.eval("a") should be(true)
+    in.eval("b") should be(true)
+    in.eval("c") should be(true)
+    in.eval("d") should be(false)
 
-    in.eval(Map("test" -> "a")) should be(Some(true))
-    in.eval(Map("test" -> "a", "foo" -> "a")) should be(Some(true))
-    in.eval(Map("test" -> "d")) should be(Some(false))
-    in.eval(Map("foo" -> "b")) should be(None)
+    val gt = GreaterThanFilter(Attr("test", ""), 5)
+
+    gt.eval(4) should be(false)
+    gt.eval(5) should be(false)
+    gt.eval(6) should be(true)
+
+    val gte = GreaterThanOrEqualFilter(Attr("test", ""), 5)
+
+    gte.eval(4) should be(false)
+    gte.eval(5) should be(true)
+    gte.eval(6) should be(true)
+
+    val lt = LessThanFilter(Attr("test", ""), 5)
+
+    lt.eval(4) should be(true)
+    lt.eval(5) should be(false)
+    lt.eval(6) should be(false)
+
+    val lte = LessThanOrEqualFilter(Attr("test", ""), 5)
+
+    lte.eval(4) should be(true)
+    lte.eval(5) should be(true)
+    lte.eval(6) should be(false)
   }
 
   "ColumnFilter" should "process correctly columns" in {
-    val f = Filter.compile(Or(
-      Or(
-        EqualTo(AttributeReference("test", StringType)(), Literal("val")),
-        IsNull(AttributeReference("test", StringType)())
+    // test = 'val' AND test IS NOT NULL AND test2 = 'val2' AND test3 IN ('a', 'b')
+    val f = Filter.compile(And(
+      And(
+        And(
+          EqualTo(AttributeReference("test", StringType)(), Literal("val")),
+          IsNotNull(AttributeReference("test", StringType)())
+        ),
+        EqualTo(AttributeReference("test2", StringType)(), Literal("val2"))
       ),
-      EqualTo(AttributeReference("test2", StringType)(), Literal("val2"))
+      In(AttributeReference("test3", StringType)(), Seq(Literal("a"), Literal("b")))
     ))
 
-    f.matchingCases should be(Map("test" -> Seq("val", null), "test2" -> Seq("val2")))
-
-    f.toString should be("((test = 'val' OR test = 'null') OR test2 = 'val2')")
-
-    f.eval(Map("test2" -> "val2")) should be(Some(true))
-    f.eval(Map("test2" -> "val1")) should be(Some(false))
-    f.eval(Map("test" -> "no")) should be(Some(false))
-    f.eval(Map("bla" -> "bla")) should be(None)
-    f.eval(Map("test" -> null)) should be(Some(true))
-
-    // TODO add more real use cases
+    f.length should be(4)
+    val filters = Filters(f)
+    filters.matches(Seq("test"), "val") should be(true)
+    filters.matches(Seq("test2"), "val") should be(false)
+    filters.matches(Seq("test3"), "b") should be(true)
   }
 
   "ColumnFilter" should "handle correctly unsupported filters" in {
     val f = Filter.compile(StartsWith(AttributeReference("test", StringType)(), Literal("a")))
 
-    f.matchingCases should be(Map())
-    f.eval(Map("test" -> "a")) should be(None)
-    f.eval(Map("test2" -> "a")) should be(None)
+    f.length should be(0)
   }
 }


### PR DESCRIPTION
This implements the ENIP-004, which makes the default behavior returning only
the last commit in a reference unless specifically asked to retrieve them all.
It has sort of a hack for making it work with the metadata source, since it
does not make use of the CommitIterator, which has a less hacky implementation.

Also, there's a complete rewrite of the filters and how they are used in the
iterators to allow more operators than just equality. As a side effect, 'OR'
operator is no longer supported. It was supported before, but only because it
was converted to an AND (and thus being a bug).

Fixes #303.
Closes #290.

### Pending tasks

- [x] update documentation
- [x] update examples
- [x] update examples inside the python package

### Warning!

This contains breaking changes and should be release in version 0.4.x! Be careful when merging this.