### PR TITLE
do not throw exception if join cannot be optimized, log warning

### DIFF
--- a/src/test/scala/tech/sourced/engine/BaseSourceSpec.scala
+++ b/src/test/scala/tech/sourced/engine/BaseSourceSpec.scala
@@ -32,15 +32,6 @@ class BaseSourceSpec(source: String)
     df.count should be(7)
   }
 
-  it should "throw an error if the plan cannot be optimized" in {
-    val ex = intercept[SparkException] {
-      val refs = engine.getRepositories.limit(1).getReferences.limit(1)
-      refs.count
-    }
-
-    ex.getMessage should startWith("Join cannot be optimized. Invalid node: ")
-  }
-
   it should "count all commits messages from all references that are not forks" in {
     val commits = engine.getRepositories.filter("is_fork = false").getReferences.getCommits
     val df = commits.select("message", "reference_name", "hash").

--- a/src/test/scala/tech/sourced/engine/DefaultSourceSpec.scala
+++ b/src/test/scala/tech/sourced/engine/DefaultSourceSpec.scala
@@ -25,11 +25,8 @@ class DefaultSourceSpec extends BaseSourceSpec("DefaultSource") {
         .and(references("name").startsWith("refs/pull"))
     ).count()
 
-    info("Files/blobs with commit hashes:\n")
-    val blobsDf = references.getCommits.getBlobs.select(
-      "path", "commit_hash"
-    )
-    out should be(37)
+    val df = references.limit(1).getCommits
+    df.count() should be(1)
   }
 
   it should "return the remote branches renamed to refs/heads" in {


### PR DESCRIPTION
Closes #267 
Closes #293 

Example output:

```
18/01/15 15:34:43 ERROR GitOptimizer: ********************************************************************************
18/01/15 15:34:43 ERROR GitOptimizer: * This Join could not be optimized. This might severely impact the performance *
18/01/15 15:34:43 ERROR GitOptimizer: * of your query. This happened because there is an unexpected node between the *
18/01/15 15:34:43 ERROR GitOptimizer: * two relations of a Join, such as Limit or another kind of unknown relation.  *
18/01/15 15:34:43 ERROR GitOptimizer: * Note that this will not stop your query or make it fail, only make it slow.  *
18/01/15 15:34:43 ERROR GitOptimizer: ********************************************************************************
18/01/15 15:34:43 ERROR GitOptimizer: * Reason:                                                                      *
18/01/15 15:34:43 ERROR GitOptimizer: * Invalid node: LocalLimit 1                                                   *
18/01/15 15:34:43 ERROR GitOptimizer: * +- Project [repository_id#79, name#80]                                       *
18/01/15 15:34:43 ERROR GitOptimizer: *    +- Relation[repository_id#79,name#80,hash#81,is_remote#82] GitRelation(or *
18/01/15 15:34:43 ERROR GitOptimizer: * g.apache.spark.sql.SparkSession@32646ecf,StructType(StructField(repository_i *
18/01/15 15:34:43 ERROR GitOptimizer: * d,StringType,false), StructField(name,StringType,false), StructField(hash,St *
18/01/15 15:34:43 ERROR GitOptimizer: * ringType,false), StructField(is_remote,BooleanType,false)),None,Some(referen *
18/01/15 15:34:43 ERROR GitOptimizer: * ces))                                                                        *
18/01/15 15:34:43 ERROR GitOptimizer: ********************************************************************************
```