### PR TITLE
Add metrics to Engine

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,6 +25,7 @@ libraryDependencies += enry % Compile
 libraryDependencies += scalaLib % Provided
 libraryDependencies += sqlite % Compile
 libraryDependencies += sqlite % Test
+libraryDependencies += metrics % Compile
 
 testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oUT")
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,4 +14,5 @@ object Dependencies {
   lazy val commonsPool = "org.apache.commons" % "commons-pool2" % "2.4.3"
   lazy val scalaLib = "org.scala-lang" % "scala-library" % "2.11.11"
   lazy val sqlite = "org.xerial" % "sqlite-jdbc" % "3.21.0"
+  lazy val metrics = "com.groupon.dse" % "spark-metrics" % "2.0.0"
 }

--- a/src/main/scala/tech/sourced/engine/DefaultSource.scala
+++ b/src/main/scala/tech/sourced/engine/DefaultSource.scala
@@ -1,5 +1,6 @@
 package tech.sourced.engine
 
+import org.apache.spark.groupon.metrics.UserMetricsSystem
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
 import org.apache.spark.sql.sources._
@@ -84,7 +85,10 @@ case class GitRelation(session: SparkSession,
 
     reposRDD.flatMap(source => {
       val provider = RepositoryProvider(reposLocalPath.value, skipCleanup)
-      val repo = provider.get(source)
+
+      val repo = UserMetricsSystem.timer("RepositoryProvider").time({
+        provider.get(source)
+      })
 
       // since the sources are ordered by their hierarchy, we can chain them like this
       // using the last used iterator as input for the current one

--- a/src/main/scala/tech/sourced/engine/Engine.scala
+++ b/src/main/scala/tech/sourced/engine/Engine.scala
@@ -5,6 +5,7 @@ import java.util.Properties
 
 import org.apache.spark.sql.functions.{lit, when}
 import org.apache.spark.SparkException
+import org.apache.spark.groupon.metrics.UserMetricsSystem
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
 import tech.sourced.engine.rule._
@@ -44,6 +45,8 @@ import scala.collection.JavaConversions.asScalaBuffer
 class Engine(session: SparkSession,
              repositoriesPath: String,
              repositoriesFormat: String) extends Logging {
+
+  UserMetricsSystem.initialize(session.sparkContext, "Engine")
 
   this.setRepositoriesPath(repositoriesPath)
   this.setRepositoriesFormat(repositoriesFormat)
@@ -341,7 +344,7 @@ private object MetadataDataFrameCompat {
       * @return new dataframe
       */
     def withStringArrayColumnAsString(column: String): DataFrame =
-      df.withColumn(column, ConcatArrayUDF(df(column), lit("|"))(df.sparkSession))
+      df.withColumn(column, ConcatArrayUDF(df.sparkSession)(df(column), lit("|")))
   }
 
 }

--- a/src/main/scala/tech/sourced/engine/udf/ClassifyLanguagesUDF.scala
+++ b/src/main/scala/tech/sourced/engine/udf/ClassifyLanguagesUDF.scala
@@ -1,9 +1,9 @@
 package tech.sourced.engine.udf
 
 import org.apache.spark.internal.Logging
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.functions.udf
-import org.apache.spark.sql.{Column, SparkSession}
 import tech.sourced.enry.Enry
 
 /** User defined function to guess languages of files. */
@@ -11,12 +11,8 @@ case object ClassifyLanguagesUDF extends CustomUDF with Logging {
 
   override val name = "classifyLanguages"
 
-  override def function(session: SparkSession = null): UserDefinedFunction =
+  override def apply(session: SparkSession): UserDefinedFunction =
     udf[Option[String], Boolean, String, Array[Byte]](getLanguage)
-
-  def apply(isBinary: Column, path: Column, content: Column): Column = {
-    function()(isBinary, path, content)
-  }
 
   /**
     * Gets the language of the given file and returns the guessed language or none.
@@ -27,18 +23,20 @@ case object ClassifyLanguagesUDF extends CustomUDF with Logging {
     * @return `None` if no language could be guessed, `Some(language)` otherwise.
     */
   private def getLanguage(isBinary: Boolean, path: String, content: Array[Byte]): Option[String] = {
-    if (isBinary) {
-      None
-    } else {
-      val lang = try {
-        Enry.getLanguage(path, content)
-      } catch {
-        case e @ (_: RuntimeException | _: Exception) =>
-          log.error(s"get language for file '$path' failed", e)
-          null
+    timer.time({
+      if (isBinary) {
+        None
+      } else {
+        val lang = try {
+          Enry.getLanguage(path, content)
+        } catch {
+          case e@(_: RuntimeException | _: Exception) =>
+            log.error(s"get language for file '$path' failed", e)
+            null
+        }
+        if (null == lang || lang.isEmpty) None else Some(lang)
       }
-      if (null == lang || lang.isEmpty) None else Some(lang)
-    }
+    })
   }
 
 }

--- a/src/main/scala/tech/sourced/engine/udf/ConcatArrayUDF.scala
+++ b/src/main/scala/tech/sourced/engine/udf/ConcatArrayUDF.scala
@@ -1,10 +1,8 @@
 package tech.sourced.engine.udf
 
-import gopkg.in.bblfsh.sdk.v1.uast.generated.Node
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.functions.udf
-import org.apache.spark.sql.{Column, SparkSession}
-import tech.sourced.engine.util.Bblfsh
 
 
 /** User defined function to concat array elements with the given separator. */
@@ -12,13 +10,8 @@ case object ConcatArrayUDF extends CustomUDF {
 
   override val name = "concatArray"
 
-  override def function(session: SparkSession): UserDefinedFunction = {
-    val configB = session.sparkContext.broadcast(Bblfsh.getConfig(session))
+  override def apply(session: SparkSession): UserDefinedFunction = {
     udf[String, Seq[String], String]((arr, sep) => arr.mkString(sep))
-  }
-
-  def apply(arr: Column, sep: Column)(implicit session: SparkSession): Column = {
-    function(session)(arr, sep)
   }
 
 }

--- a/src/main/scala/tech/sourced/engine/udf/CustomUDF.scala
+++ b/src/main/scala/tech/sourced/engine/udf/CustomUDF.scala
@@ -1,5 +1,7 @@
 package tech.sourced.engine.udf
 
+import org.apache.spark.groupon.metrics.{NotInitializedException, SparkTimer, UserMetricsSystem}
+import org.apache.spark.internal.Logging
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.expressions.UserDefinedFunction
 
@@ -7,9 +9,37 @@ import org.apache.spark.sql.expressions.UserDefinedFunction
   * Custom named user defined function.
   */
 abstract class CustomUDF {
+  /** timer intended to be used on UDF logic **/
+  lazy protected val timer: SparkTimerUDFWrapper = new SparkTimerUDFWrapper(name)
+
   /** Name of the function. */
   val name: String
 
   /** Function to execute when this function is called. */
-  def function(session: SparkSession): UserDefinedFunction
+  def apply(session: SparkSession): UserDefinedFunction
+
+  def apply(): UserDefinedFunction = this.apply(session = null)
+}
+
+sealed class SparkTimerUDFWrapper(name: String) extends Logging {
+  lazy val timer: SparkTimer = init()
+
+  private def init(): SparkTimer = {
+    try {
+      UserMetricsSystem.timer(name)
+    } catch {
+      case _: NotInitializedException => {
+        logWarning("SparMetric not initialized on UDF")
+        null
+      }
+    }
+
+  }
+
+  def time[T](f: => T): T =
+    if (timer == null) {
+      f
+    } else {
+      timer.time(f)
+    }
 }

--- a/src/main/scala/tech/sourced/engine/udf/ExtractTokensUDF.scala
+++ b/src/main/scala/tech/sourced/engine/udf/ExtractTokensUDF.scala
@@ -1,28 +1,26 @@
 package tech.sourced.engine.udf
 
 import gopkg.in.bblfsh.sdk.v1.uast.generated.Node
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.functions.udf
-import org.apache.spark.sql.{Column, SparkSession}
 
 /** User defined function to extract tokens from an UAST. */
 case object ExtractTokensUDF extends CustomUDF {
 
   override val name = "extractTokens"
 
-  override def function(session: SparkSession = null): UserDefinedFunction =
+  override def apply(session: SparkSession): UserDefinedFunction =
     udf[Seq[String], Seq[Array[Byte]]](extractTokens)
 
-  def apply(uast: Column): Column = {
-    function()(uast)
-  }
-
   private def extractTokens(nodes: Seq[Array[Byte]]): Seq[String] = {
-    if (nodes == null) {
-      Seq()
-    } else {
-      nodes.map(Node.parseFrom).map(_.token)
-    }
+    timer.time({
+      if (nodes == null) {
+        Seq()
+      } else {
+        nodes.map(Node.parseFrom).map(_.token)
+      }
+    })
   }
 
 }

--- a/src/main/scala/tech/sourced/engine/udf/ExtractUASTsUDF.scala
+++ b/src/main/scala/tech/sourced/engine/udf/ExtractUASTsUDF.scala
@@ -1,8 +1,8 @@
 package tech.sourced.engine.udf
 
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.functions.udf
-import org.apache.spark.sql.{Column, SparkSession}
 import tech.sourced.engine.util.Bblfsh
 
 trait ExtractUASTsUDF {
@@ -20,57 +20,15 @@ trait ExtractUASTsUDF {
 
 }
 
-/** Common entry point to use extraction UAST UDFs with or without language. */
-object ExtractUASTsUDF {
-
-  def apply(path: Column,
-            content: Column,
-            lang: Column = null)(
-             implicit session: SparkSession): Column = {
-    if (lang == null) {
-      ExtractUASTsWithoutLangUDF(path, content)
-    } else {
-      ExtractUASTsWithLangUDF(path, content, lang)
-    }
-  }
-
-}
-
-/** User defined function to extract UASTs with no provided language for files. */
-case object ExtractUASTsWithoutLangUDF extends CustomUDF with ExtractUASTsUDF {
+/** Common entry point to use extraction UAST UDFs with or without language parameter. */
+case object ExtractUASTsUDF extends CustomUDF with ExtractUASTsUDF {
 
   override val name = "extractUASTs"
 
-  override def function(session: SparkSession): UserDefinedFunction = {
-    val configB = session.sparkContext.broadcast(Bblfsh.getConfig(session))
-    udf[Seq[Array[Byte]], String, Array[Byte]]((path, content) =>
-      extractUASTs(path, content, config = configB.value))
-  }
-
-  def apply(path: Column,
-            content: Column)(
-             implicit session: SparkSession): Column = {
-    function(session)(path, content)
-  }
-
-}
-
-/** User defined function to extract UASTs providing files' language. */
-case object ExtractUASTsWithLangUDF extends CustomUDF with ExtractUASTsUDF {
-
-  override val name = "extractUASTsWithLang"
-
-  override def function(session: SparkSession): UserDefinedFunction = {
+  override def apply(session: SparkSession): UserDefinedFunction = {
     val configB = session.sparkContext.broadcast(Bblfsh.getConfig(session))
     udf[Seq[Array[Byte]], String, Array[Byte], String]((path, content, lang) =>
       extractUASTs(path, content, lang, configB.value))
-  }
-
-  def apply(path: Column,
-            content: Column,
-            lang: Column)(
-             implicit session: SparkSession): Column = {
-    function(session)(path, content, lang)
   }
 
 }

--- a/src/main/scala/tech/sourced/engine/udf/QueryXPathUDF.scala
+++ b/src/main/scala/tech/sourced/engine/udf/QueryXPathUDF.scala
@@ -1,9 +1,9 @@
 package tech.sourced.engine.udf
 
 import gopkg.in.bblfsh.sdk.v1.uast.generated.Node
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.functions.udf
-import org.apache.spark.sql.{Column, SparkSession}
 import tech.sourced.engine.util.Bblfsh
 
 
@@ -12,31 +12,29 @@ case object QueryXPathUDF extends CustomUDF {
 
   override val name = "queryXPath"
 
-  override def function(session: SparkSession): UserDefinedFunction = {
+  override def apply(session: SparkSession): UserDefinedFunction = {
     val configB = session.sparkContext.broadcast(Bblfsh.getConfig(session))
     udf[Seq[Array[Byte]], Seq[Array[Byte]], String]((nodes, query) =>
       queryXPath(nodes, query, configB.value))
   }
 
-  def apply(uast: Column, query: Column)(implicit session: SparkSession): Column = {
-    function(session)(uast, query)
-  }
-
   private def queryXPath(nodes: Seq[Array[Byte]],
                          query: String,
                          config: Bblfsh.Config): Seq[Array[Byte]] = {
-    if (nodes == null) {
-      return null
-    }
-
-    nodes.map(Node.parseFrom).flatMap(n => {
-      val result = Bblfsh.filter(n, query, config)
-      if (result == null) {
-        None
-      } else {
-        result.toIterator
+    timer.time({
+      if (nodes == null) {
+        return null
       }
-    }).map(_.toByteArray)
+
+      nodes.map(Node.parseFrom).flatMap(n => {
+        val result = Bblfsh.filter(n, query, config)
+        if (result == null) {
+          None
+        } else {
+          result.toIterator
+        }
+      }).map(_.toByteArray)
+    })
   }
 
 }

--- a/src/test/scala/tech/sourced/engine/udf/CustomUDFSpec.scala
+++ b/src/test/scala/tech/sourced/engine/udf/CustomUDFSpec.scala
@@ -86,12 +86,12 @@ class CustomUDFSpec extends FlatSpec with Matchers with BaseSparkSpec {
     import spark.implicits._
 
     spark.catalog.listFunctions()
-      .filter('name like "%" + ExtractUASTsWithoutLangUDF.name + "%")
+      .filter('name like "%" + ExtractUASTsUDF.name + "%")
 
     fileSeq.toDF(fileColumns: _*).createOrReplaceTempView("uasts")
 
     val uastsDF = spark.sqlContext.sql("SELECT *, "
-      + ExtractUASTsWithoutLangUDF.name + "(path, content) AS uast FROM uasts")
+      + ExtractUASTsUDF.name + "(path, content) AS uast FROM uasts")
     uastsDF.collect
     uastsDF.columns should contain("uast")
   }
@@ -103,7 +103,7 @@ class CustomUDFSpec extends FlatSpec with Matchers with BaseSparkSpec {
     fileSeq.take(1).toDF(fileColumns: _*).createOrReplaceTempView("files")
 
     val uastsDF = spark.sqlContext
-      .sql(s"SELECT path, ${ExtractUASTsWithoutLangUDF.name}" + s"(path, content) "
+      .sql(s"SELECT path, ${ExtractUASTsUDF.name}" + s"(path, content) "
         + s"as uast FROM files")
 
     val uast = uastsDF.first()

--- a/src/test/scala/tech/sourced/engine/udf/CustomUDFSpec.scala
+++ b/src/test/scala/tech/sourced/engine/udf/CustomUDFSpec.scala
@@ -91,7 +91,7 @@ class CustomUDFSpec extends FlatSpec with Matchers with BaseSparkSpec {
     fileSeq.toDF(fileColumns: _*).createOrReplaceTempView("uasts")
 
     val uastsDF = spark.sqlContext.sql("SELECT *, "
-      + ExtractUASTsUDF.name + "(path, content) AS uast FROM uasts")
+      + ExtractUASTsUDF.name + "(path, content, null) AS uast FROM uasts")
     uastsDF.collect
     uastsDF.columns should contain("uast")
   }
@@ -103,7 +103,7 @@ class CustomUDFSpec extends FlatSpec with Matchers with BaseSparkSpec {
     fileSeq.take(1).toDF(fileColumns: _*).createOrReplaceTempView("files")
 
     val uastsDF = spark.sqlContext
-      .sql(s"SELECT path, ${ExtractUASTsUDF.name}" + s"(path, content) "
+      .sql(s"SELECT path, ${ExtractUASTsUDF.name}" + s"(path, content, null) "
         + s"as uast FROM files")
 
     val uast = uastsDF.first()


### PR DESCRIPTION
First step to add Spark custom metrics from engine parts using spark-metrics project.

Addded timers on all critical UDFs and on repository provider.

UDF structure has been slightly refactored to avoid duplicated and unnecesary code.

Signed-off-by: Antonio Jesus Navarro Perez <antnavper@gmail.com>