### PR TITLE
Make Engine's session member public

### DIFF
--- a/src/main/scala/tech/sourced/engine/Engine.scala
+++ b/src/main/scala/tech/sourced/engine/Engine.scala
@@ -42,7 +42,7 @@ import scala.collection.JavaConversions.asScalaBuffer
   * @constructor creates a Engine instance with the given Spark session.
   * @param session Spark session to be used
   */
-class Engine(session: SparkSession,
+class Engine(val session: SparkSession,
              repositoriesPath: String,
              repositoriesFormat: String) extends Logging {
 


### PR DESCRIPTION
I think is valuable to have the `session` member publicly available since it allows you to pass an `Engine` object throw your code containing all you need from `spark`.

For example, when engine is used by a third app you could want import `spark.sqlContext.implicits._` in some parts of your code. Having the session member available you don't need to pass the spark session and engine to those parts, just engine and use `import engine.session.sqlContext.implicits._`