### PR TITLE
replace classifyLanguages and extractUASTs UDFs with maps

### DIFF
--- a/src/main/scala/tech/sourced/engine/udf/ClassifyLanguagesUDF.scala
+++ b/src/main/scala/tech/sourced/engine/udf/ClassifyLanguagesUDF.scala
@@ -22,7 +22,7 @@ case object ClassifyLanguagesUDF extends CustomUDF with Logging {
     * @param content  file content
     * @return `None` if no language could be guessed, `Some(language)` otherwise.
     */
-  private def getLanguage(isBinary: Boolean, path: String, content: Array[Byte]): Option[String] = {
+  def getLanguage(isBinary: Boolean, path: String, content: Array[Byte]): Option[String] = {
     timer.time({
       if (isBinary) {
         None


### PR DESCRIPTION
Fixes #314 

Because of Spark optimizations, costly UDFs (and all UDFs, actually) may be invoked more than once. When the UDF is a substring or something like that, it's ok, but when your UDF computes the UAST of a blob or guesses its language, the thing becomes a little more delicate. Over a huge dataset, this could mean extracting the UAST and the language up to tens of times for each single blob! Which not only makes everything slow but sends a lot more jobs to babelfish.

To avoid this, we came up with this solution, use a `map` and transform the `Row`. That way, since it's not an UDF, it does not get done more than once. We still keep the UDFs just in case someone wants to execute them in a SQL query, though they would incur in the aforementioned issues, but that's ok.

Of course, this comes with an overhead. If the only thing you're doing is extracting the UAST (that is, there is no repeated call to bblfsh) you will see a bit of a slowdown, though it is not very significant.
Although this slowdown is bad, it is outweighed by the fact that when you do something with the UAST, such as querying with XPath or something like that, there is a significant speedup. Most of the time you will be doing stuff with the UAST after computing it, so the trade-off, IMO, is worth it.

As the number of blobs gets bigger, so does the speedup with this method.

**442 blobs without UDF repetition**
- UDFs: 28s328ms
- Maps: 31s257ms

**19 blobs with UDF repetition**
- UDFs: 7s497ms
- Maps: 7s654ms

**100 blobs with UDF repetition**
- UDFs: 30s638ms
- Maps: 28s494ms

**200 blobs with UDF repetition**
- UDFs: 37s502ms
- Maps: 32s911s

As we can see, as the number of blobs get bigger, so does the speedup using this approach. Which makes us think, when there are thousands of blobs to analyze, the speedup will be huge.