### PR TITLE
replace makefile build with docker multi-stage build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,2 @@
 # Exclude all directories and files except those used by Dockerfile to build the image
-*
-!target/engine-uber.jar
-!examples/
-!python/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,9 @@
+FROM openjdk:8-jdk as builder
+RUN mkdir /engine
+WORKDIR /engine
+COPY . /engine
+RUN ./sbt assembly
+
 FROM srcd/jupyter-spark:5.2.1
 
 RUN mkdir -p /opt/
@@ -17,7 +23,7 @@ USER root
 
 COPY ./python /opt/python-engine/
 COPY ./examples/notebooks/* /home/$NB_USER/
-ADD ./target/engine-uber.jar /opt/jars/
+COPY --from=builder /engine/target/engine-uber.jar /opt/jars/
 
 
 RUN echo "local" > /opt/python-engine/version.txt \

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ docker-bblfsh-install-drivers:
 docker-bblfsh-list-drivers:
 	$(DOCKER_EXEC) $(BBLFSH_LIST_DRIVERS)
 
-docker-build: build
+docker-build:
 	$(DOCKER_BUILD) -t $(call unescape_docker_tag,$(JUPYTER_IMAGE_VERSIONED)) .
 
 docker-run:


### PR DESCRIPTION
Fixes #318 

Advantages:
- No environment required to build the image

Downsides:
- Takes a lot more to build
- Adds a lot more files to the docker context (we need to build the jar inside, can't put them in the `.dockerignore`)