### PR TITLE
Limit the number of repositories kept in the pool

### DIFF
--- a/src/main/scala/tech/sourced/engine/DefaultSource.scala
+++ b/src/main/scala/tech/sourced/engine/DefaultSource.scala
@@ -64,6 +64,7 @@ case class GitRelation(session: SparkSession,
   private val repositoriesFormat: String = session.conf.get(RepositoriesFormatKey)
   private val skipCleanup: Boolean = session.conf.
     get(SkipCleanupKey, default = "false").toBoolean
+  private val parallelism: Int = session.sparkContext.defaultParallelism
 
   // this needs to be overridden to extend BaseRelataion,
   // though is not very useful since already we have the SparkSession
@@ -84,7 +85,7 @@ case class GitRelation(session: SparkSession,
     val filtersBySource = sc.broadcast(Sources.getFiltersBySource(filters))
 
     reposRDD.flatMap(source => {
-      val provider = RepositoryProvider(reposLocalPath.value, skipCleanup)
+      val provider = RepositoryProvider(reposLocalPath.value, skipCleanup, parallelism * 2)
 
       val repo = UserMetricsSystem.timer("RepositoryProvider").time({
         provider.get(source)

--- a/src/main/scala/tech/sourced/engine/MetadataSource.scala
+++ b/src/main/scala/tech/sourced/engine/MetadataSource.scala
@@ -118,7 +118,7 @@ case class MetadataRelation(session: SparkSession,
               filtersBySource.value.getOrElse("blobs", Seq())
             )
 
-            new CleanupIterator[Row](iter, repo.close())
+            new CleanupIterator[Row](iter, provider.close(source, repo))
         }
     } else {
       metadataRDD

--- a/src/main/scala/tech/sourced/engine/MetadataSource.scala
+++ b/src/main/scala/tech/sourced/engine/MetadataSource.scala
@@ -64,6 +64,7 @@ case class MetadataRelation(session: SparkSession,
   private val repositoriesFormat: String = session.conf.get(RepositoriesFormatKey)
   private val skipCleanup: Boolean = session.conf.
     get(SkipCleanupKey, default = "false").toBoolean
+  private val parallelism: Int = session.sparkContext.defaultParallelism
 
   override def sqlContext: SQLContext = session.sqlContext
 
@@ -106,7 +107,7 @@ case class MetadataRelation(session: SparkSession,
             }
 
             val source = repoSources.head
-            val provider = RepositoryProvider(reposLocalPath.value, skipCleanup)
+            val provider = RepositoryProvider(reposLocalPath.value, skipCleanup, parallelism * 2)
             val repo = provider.get(source)
 
             val finalCols = requiredCols.value.map(_.name)

--- a/src/main/scala/tech/sourced/engine/provider/RepositoryProvider.scala
+++ b/src/main/scala/tech/sourced/engine/provider/RepositoryProvider.scala
@@ -42,7 +42,6 @@ class RepositoryProvider(val localPath: String,
     maxTotal
   }
 
-  // TODO parametrize
   repositoryPool.setMaxTotalPerKey(numTables)
   repositoryPool.setMaxIdlePerKey(numTables)
   repositoryPool.setMaxTotal(total)

--- a/src/main/scala/tech/sourced/engine/provider/RepositoryProvider.scala
+++ b/src/main/scala/tech/sourced/engine/provider/RepositoryProvider.scala
@@ -259,7 +259,7 @@ object RepositoryProvider {
   def apply(localPath: String,
             skipCleanup: Boolean = false,
             maxTotal: Int = 64): RepositoryProvider = {
-    if (provider == null) {
+    if (provider == null || provider.localPath != localPath) {
       provider = new RepositoryProvider(localPath, skipCleanup = skipCleanup, maxTotal = maxTotal)
     }
 

--- a/src/test/scala/tech/sourced/engine/iterator/BaseChainableIterator.scala
+++ b/src/test/scala/tech/sourced/engine/iterator/BaseChainableIterator.scala
@@ -8,12 +8,18 @@ import tech.sourced.engine.provider.{RepositoryProvider, RepositorySource, Repos
 import tech.sourced.engine.{BaseSivaSpec, BaseSparkSpec}
 
 trait BaseChainableIterator extends Suite with BaseSparkSpec with BaseSivaSpec with Matchers {
+  override def afterAll(): Unit = {
+    super.afterAll()
+    provider.close(source, repo)
+  }
+
   lazy val prov: RepositoryRDDProvider = RepositoryRDDProvider(ss.sparkContext)
   lazy val rdd: RDD[RepositorySource] = prov.get(resourcePath, RepositoryRDDProvider.SivaFormat)
 
   lazy val source: RepositorySource = rdd.filter(source => source.pds.getPath()
     .endsWith("fff7062de8474d10a67d417ccea87ba6f58ca81d.siva")).first()
-  lazy val repo: Repository = RepositoryProvider("/tmp").get(source)
+  lazy val provider: RepositoryProvider = RepositoryProvider("/tmp")
+  lazy val repo: Repository = provider.get(source)
 
   def testIterator(iterator: (Repository) => Iterator[Row],
                    matcher: (Int, Row) => Unit,
@@ -31,5 +37,4 @@ trait BaseChainableIterator extends Suite with BaseSparkSpec with BaseSivaSpec w
 
     count should be(total)
   }
-
 }

--- a/src/test/scala/tech/sourced/engine/iterator/RepositoryIteratorSpec.scala
+++ b/src/test/scala/tech/sourced/engine/iterator/RepositoryIteratorSpec.scala
@@ -90,7 +90,8 @@ class RepositoryIteratorSpec extends FlatSpec with BaseChainableIterator with Be
     val rdd = RepositoryRDDProvider(ss.sparkContext)
       .get(tmpDir.toString, RepositoryRDDProvider.StandardFormat)
     val source = rdd.first()
-    val repo = RepositoryProvider(tmpDir.toString).get(source)
+    val provider = RepositoryProvider(tmpDir.toString)
+    val repo = provider.get(source)
 
     val iter = new RepositoryIterator("/foo/bar", Array("id"), repo, Seq())
     val repos = iter.toList
@@ -98,6 +99,8 @@ class RepositoryIteratorSpec extends FlatSpec with BaseChainableIterator with Be
     repos.length should be(2)
     repos.head(0).toString should be("github.com/git/repo")
     repos(1)(0).toString should startWith("file://")
+
+    provider.close(source, repo)
   }
 
 }


### PR DESCRIPTION
The limit is set to the double of the number of parallelism. Without thischange there could be OutOfMemory problems when processing big repos.

Fixes #319 