### PR TITLE
[WIP] Limit the number of repositories kept in the pool

### DIFF
--- a/src/main/scala/tech/sourced/engine/DefaultSource.scala
+++ b/src/main/scala/tech/sourced/engine/DefaultSource.scala
@@ -64,6 +64,7 @@ case class GitRelation(session: SparkSession,
   private val repositoriesFormat: String = session.conf.get(RepositoriesFormatKey)
   private val skipCleanup: Boolean = session.conf.
     get(SkipCleanupKey, default = "false").toBoolean
+  private val parallelism: Int = session.sparkContext.defaultParallelism
 
   // this needs to be overridden to extend BaseRelataion,
   // though is not very useful since already we have the SparkSession
@@ -84,7 +85,7 @@ case class GitRelation(session: SparkSession,
     val filtersBySource = sc.broadcast(Sources.getFiltersBySource(filters))
 
     reposRDD.flatMap(source => {
-      val provider = RepositoryProvider(reposLocalPath.value, skipCleanup)
+      val provider = RepositoryProvider(reposLocalPath.value, skipCleanup, parallelism * 2)
 
       val repo = UserMetricsSystem.timer("RepositoryProvider").time({
         provider.get(source)

--- a/src/main/scala/tech/sourced/engine/MetadataSource.scala
+++ b/src/main/scala/tech/sourced/engine/MetadataSource.scala
@@ -64,6 +64,7 @@ case class MetadataRelation(session: SparkSession,
   private val repositoriesFormat: String = session.conf.get(RepositoriesFormatKey)
   private val skipCleanup: Boolean = session.conf.
     get(SkipCleanupKey, default = "false").toBoolean
+  private val parallelism: Int = session.sparkContext.defaultParallelism
 
   override def sqlContext: SQLContext = session.sqlContext
 
@@ -106,7 +107,7 @@ case class MetadataRelation(session: SparkSession,
             }
 
             val source = repoSources.head
-            val provider = RepositoryProvider(reposLocalPath.value, skipCleanup)
+            val provider = RepositoryProvider(reposLocalPath.value, skipCleanup, parallelism * 2)
             val repo = provider.get(source)
 
             val finalCols = requiredCols.value.map(_.name)

--- a/src/main/scala/tech/sourced/engine/provider/RepositoryProvider.scala
+++ b/src/main/scala/tech/sourced/engine/provider/RepositoryProvider.scala
@@ -42,8 +42,8 @@ class RepositoryProvider(val localPath: String,
     maxTotal
   }
 
-  repositoryPool.setMaxTotalPerKey(numTables)
-  repositoryPool.setMaxIdlePerKey(numTables)
+  repositoryPool.setMaxTotalPerKey(25)
+  repositoryPool.setMaxIdlePerKey(25)
   repositoryPool.setMaxTotal(total)
   repositoryPool.setBlockWhenExhausted(true)
 

--- a/src/main/scala/tech/sourced/engine/provider/RepositoryProvider.scala
+++ b/src/main/scala/tech/sourced/engine/provider/RepositoryProvider.scala
@@ -36,15 +36,15 @@ class RepositoryProvider(val localPath: String,
 
   // The minimum number of total instances must be at least equal to the number of tables that
   // can be processed at the same time.
-  private val total = if (maxTotal <= numTables) {
-    numTables
+  private val total = if (maxTotal <= numTables * 10) {
+    numTables * 10
   } else {
     maxTotal
   }
 
   repositoryPool.setMaxTotalPerKey(numTables)
   repositoryPool.setMaxIdlePerKey(numTables)
-  /* repositoryPool.setMaxTotal(total) */
+  repositoryPool.setMaxTotal(total)
   repositoryPool.setBlockWhenExhausted(true)
 
   /**

--- a/src/main/scala/tech/sourced/engine/provider/RepositoryProvider.scala
+++ b/src/main/scala/tech/sourced/engine/provider/RepositoryProvider.scala
@@ -44,7 +44,7 @@ class RepositoryProvider(val localPath: String,
 
   repositoryPool.setMaxTotalPerKey(numTables)
   repositoryPool.setMaxIdlePerKey(numTables)
-  repositoryPool.setMaxTotal(total)
+  /* repositoryPool.setMaxTotal(total) */
   repositoryPool.setBlockWhenExhausted(true)
 
   /**

--- a/src/main/scala/tech/sourced/engine/provider/RepositoryProvider.scala
+++ b/src/main/scala/tech/sourced/engine/provider/RepositoryProvider.scala
@@ -10,6 +10,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.internal.Logging
 import org.eclipse.jgit.lib.{Repository, RepositoryBuilder}
+import tech.sourced.engine.Sources
 import tech.sourced.engine.util.MD5Gen
 import tech.sourced.siva.SivaReader
 
@@ -21,17 +22,29 @@ import scala.collection.JavaConverters._
   *
   * @param localPath   Local path where siva files are.
   * @param skipCleanup Skip deleting files after they reference count of a repository gets to 0.
+  * @param maxTotal    Maximum number of repositories to keep in the pool.
   */
-class RepositoryProvider(val localPath: String, val skipCleanup: Boolean = false)
+class RepositoryProvider(val localPath: String,
+                         val skipCleanup: Boolean = false,
+                         maxTotal: Int = 64)
   extends Logging {
   private val repositoryObjectFactory =
     new RepositoryObjectFactory(localPath, skipCleanup)
   private val repositoryPool =
     new GenericKeyedObjectPool[RepositoryKey, Repository](repositoryObjectFactory)
+  private val numTables = Sources.orderedSources.length
 
-  // TODO parametrize
-  repositoryPool.setMaxTotalPerKey(5)
-  repositoryPool.setMaxIdlePerKey(4)
+  // The minimum number of total instances must be at least equal to the number of tables that
+  // can be processed at the same time.
+  private val total = if (maxTotal <= numTables) {
+    numTables
+  } else {
+    maxTotal
+  }
+
+  repositoryPool.setMaxTotalPerKey(numTables)
+  repositoryPool.setMaxIdlePerKey(numTables)
+  repositoryPool.setMaxTotal(total)
   repositoryPool.setBlockWhenExhausted(true)
 
   /**
@@ -240,11 +253,14 @@ object RepositoryProvider {
     * @constructor
     * @param localPath   local path where rooted repositories are downloaded from the remote FS
     * @param skipCleanup skip cleanup after some operations
+    * @param maxTotal    Maximum number of repositories to keep in the pool
     * @return a new repository provider or an already existing one if there is one
     */
-  def apply(localPath: String, skipCleanup: Boolean = false): RepositoryProvider = {
+  def apply(localPath: String,
+            skipCleanup: Boolean = false,
+            maxTotal: Int = 64): RepositoryProvider = {
     if (provider == null) {
-      provider = new RepositoryProvider(localPath, skipCleanup = skipCleanup)
+      provider = new RepositoryProvider(localPath, skipCleanup = skipCleanup, maxTotal = maxTotal)
     }
 
     provider


### PR DESCRIPTION
The limit is set to the double of the number of parallelism. Without this change there could be `OutOfMemory` problems when processing big repos.