### PR TITLE
add jgit ReadOnlyFileRepository implementation.

### DIFF
--- a/src/main/scala/tech/sourced/engine/provider/ReadOnlyFileRepository.scala
+++ b/src/main/scala/tech/sourced/engine/provider/ReadOnlyFileRepository.scala
@@ -1,0 +1,29 @@
+package tech.sourced.engine.provider
+
+import java.io.File
+
+import org.eclipse.jgit.internal.storage.file.FileRepository
+import org.eclipse.jgit.storage.file.FileBasedConfig
+
+/**
+  * [[FileRepository]] implementation for read-only repositories.
+  *
+  * Some operations are performance optimized for this case. If the underlying repository changes,
+  * usage of this repository implementation might lead to unexpected results.
+  *
+  * @param gitDir Path to the git directory.
+  */
+private[provider] class ReadOnlyFileRepository(gitDir: File) extends FileRepository(gitDir) {
+
+  /** @inheritdoc */
+  override lazy val getConfig: FileBasedConfig = {
+    //XXX: repoConfig is initialized in FileRepository's constructor.
+    //     Here we always return it without checking for changes in the underlying
+    //     filesystem. This prevents checking for last modification date of configuration
+    //     files on every operation.
+    val accessor = classOf[FileRepository].getDeclaredField("repoConfig")
+    accessor.setAccessible(true)
+    accessor.get(this).asInstanceOf[FileBasedConfig]
+  }
+
+}

--- a/src/main/scala/tech/sourced/engine/provider/RepositoryProvider.scala
+++ b/src/main/scala/tech/sourced/engine/provider/RepositoryProvider.scala
@@ -229,7 +229,8 @@ class RepositoryObjectFactory(val localPath: String, val skipCleanup: Boolean)
     }
 
     // After copy create a repository instance using the local path
-    val repo = new RepositoryBuilder().setGitDir(new File(localUnpackedPath.toString)).build()
+    val gitDir = new File(localUnpackedPath.toString)
+    val repo = new ReadOnlyFileRepository(gitDir)
 
     // delete siva file
     if (!skipCleanup && !isLocalSivaFile) {


### PR DESCRIPTION
Jgit's `FileRepository` checks 3 configuration files'
last modification date on every `getConfig`. This leads
to a big performance hit on some operations.

This commit adds a ReadOnlyFileRepository for optimizations
when the underlying repository is not expected to change.

It is now used for temporary repositories created out of siva
files.