### PR TITLE
Catch RevWalkException in RefWithCommitIterator.hasNext

### DIFF
--- a/src/main/scala/tech/sourced/engine/iterator/CommitIterator.scala
+++ b/src/main/scala/tech/sourced/engine/iterator/CommitIterator.scala
@@ -154,13 +154,13 @@ private[iterator] class RefWithCommitIterator(repo: Repository,
             .call().asScala.toIterator
         } catch {
           case e: IncorrectObjectTypeException =>
-            log.warn("incorrect object found", e)
+            log.warn(s"incorrect object found for ${repoInfo}", e)
             null
           case e: MissingObjectException =>
-            log.warn("missing object", e)
+            log.warn(s"missing object for ${repoInfo}", e)
             null
           case e: RevWalkException =>
-            log.warn("rev walk error", e)
+            log.warn(s"rev walk error for ${repoInfo}", e)
             null
         }
     }
@@ -179,7 +179,7 @@ private[iterator] class RefWithCommitIterator(repo: Repository,
         true
       } catch {
         case e: RevWalkException =>
-          log.warn("rev walk error", e)
+          log.warn(s"rev walk error for ${repoInfo}", e)
           this.hasNext
       }
     } else {
@@ -202,4 +202,11 @@ private[iterator] class RefWithCommitIterator(repo: Repository,
     result
   }
 
+  private def repoInfo(): String = {
+    val c = repo.getConfig
+    val remotes = c.getSubsections("remote").asScala
+    val urls = remotes.flatMap(r => c.getStringList("remote", r, "url"))
+
+    s"${repo.toString}; urls ${urls.mkString(", ")}"
+  }
 }

--- a/src/main/scala/tech/sourced/engine/iterator/CommitIterator.scala
+++ b/src/main/scala/tech/sourced/engine/iterator/CommitIterator.scala
@@ -159,6 +159,9 @@ private[iterator] class RefWithCommitIterator(repo: Repository,
           case e: MissingObjectException =>
             log.warn("missing object", e)
             null
+          case e: RevWalkException =>
+            log.warn("rev walk error", e)
+            null
         }
     }
 


### PR DESCRIPTION
Fix #336.

A `RevWalkException` is thrown by `org.eclipse.jgit.revwalk.RevWalk.iterator` outside of the try/catch added in #347.
