### PR TITLE
Change ignored errors log level to debug

### DIFF
--- a/src/main/scala/tech/sourced/engine/iterator/CommitIterator.scala
+++ b/src/main/scala/tech/sourced/engine/iterator/CommitIterator.scala
@@ -154,7 +154,7 @@ private[iterator] class RefWithCommitIterator(repo: Repository,
             .call().asScala.toIterator
         } catch {
           case e: IncorrectObjectTypeException =>
-            log.warn(s"incorrect object found for ${repoInfo}", e)
+            log.debug(s"incorrect object found for ${repoInfo}", e)
             null
           case e: MissingObjectException =>
             log.warn(s"missing object for ${repoInfo}", e)

--- a/src/main/scala/tech/sourced/engine/iterator/GitTreeEntryIterator.scala
+++ b/src/main/scala/tech/sourced/engine/iterator/GitTreeEntryIterator.scala
@@ -157,7 +157,7 @@ object GitTreeEntryIterator extends Logging {
           }
         } catch {
           case e: IncorrectObjectTypeException =>
-            log.warn("incorrect object found", e)
+            log.debug("incorrect object found", e)
           case e: MissingObjectException =>
             log.warn("missing object", e)
         }


### PR DESCRIPTION
Implements #354.

The logs for errors that are ignored now have `debug` level. There are still some logs left as warnings because they look relevant to me, i.e. in MetadataIterator the messages about failing DB connections are still reported as warnings.