### PR TITLE
Add detailed debug info when an iterator crashes

### DIFF
--- a/src/main/scala/tech/sourced/engine/iterator/BlobIterator.scala
+++ b/src/main/scala/tech/sourced/engine/iterator/BlobIterator.scala
@@ -20,7 +20,8 @@ class BlobIterator(finalColumns: Array[String],
   extends ChainableIterator[Blob](
     finalColumns,
     Option(prevIter).orNull,
-    filters
+    filters,
+    repo
   ) with Logging {
 
   /** @inheritdoc */

--- a/src/main/scala/tech/sourced/engine/iterator/ChainableIterator.scala
+++ b/src/main/scala/tech/sourced/engine/iterator/ChainableIterator.scala
@@ -1,6 +1,7 @@
 package tech.sourced.engine.iterator
 
 import org.apache.spark.sql.Row
+import org.eclipse.jgit.lib.Repository
 import tech.sourced.engine.util.CompiledFilter
 
 import scala.annotation.tailrec
@@ -15,7 +16,8 @@ import scala.annotation.tailrec
   */
 abstract class ChainableIterator[T](finalColumns: Array[String],
                                     prevIter: ChainableIterator[_],
-                                    filters: Seq[CompiledFilter]) extends Iterator[Row] {
+                                    filters: Seq[CompiledFilter],
+                                    val repo:Repository) extends Iterator[Row] {
 
   /** Raw values of the row. */
   type RawRow = Map[String, Any]

--- a/src/main/scala/tech/sourced/engine/iterator/CleanupIterator.scala
+++ b/src/main/scala/tech/sourced/engine/iterator/CleanupIterator.scala
@@ -11,7 +11,7 @@ import org.apache.spark.{InterruptibleIterator, TaskContext}
   * @tparam T type of the rows in the iterator
   */
 class CleanupIterator[T](it: Iterator[T], cleanup: => Unit)
-  extends InterruptibleIterator[T](TaskContext.get(), it) {
+    extends InterruptibleIterator[T](TaskContext.get(), it) {
 
   /** @inheritdoc
     *
@@ -26,7 +26,7 @@ class CleanupIterator[T](it: Iterator[T], cleanup: => Unit)
       }
       hasNext
     } catch {
-      case e @ (_: Exception | _: RuntimeException) =>
+      case e: Exception =>
         it match {
           case it: ChainableIterator[_] =>
             throw new RepositoryException(it.repo, e)

--- a/src/main/scala/tech/sourced/engine/iterator/CleanupIterator.scala
+++ b/src/main/scala/tech/sourced/engine/iterator/CleanupIterator.scala
@@ -26,17 +26,22 @@ class CleanupIterator[T](it: Iterator[T], cleanup: => Unit)
       }
       hasNext
     } catch {
-      case e: Exception =>
-        it match {
-          case it: ChainableIterator[_] =>
-            throw new RepositoryException(it.repo, e)
-          case _ =>
-            throw e
-        }
       case e: Throwable =>
-        throw e
-    } finally {
-      val _ = cleanup
+        val detailedException = (
+          e match {
+            case e: Exception =>
+              it match {
+                case it: ChainableIterator[_] =>
+                  new RepositoryException(it.repo, e)
+                case _ =>
+                  e
+              }
+            case _ =>
+              e
+          })
+
+        val _ = cleanup
+        throw detailedException
     }
   }
 

--- a/src/main/scala/tech/sourced/engine/iterator/CleanupIterator.scala
+++ b/src/main/scala/tech/sourced/engine/iterator/CleanupIterator.scala
@@ -26,9 +26,17 @@ class CleanupIterator[T](it: Iterator[T], cleanup: => Unit)
       }
       hasNext
     } catch {
+      case e @ (_: Exception | _: RuntimeException) =>
+        it match {
+          case it: ChainableIterator[_] =>
+            throw new RepositoryException(it.repo, e)
+          case _ =>
+            throw e
+        }
       case e: Throwable =>
-        val _ = cleanup
         throw e
+    } finally {
+      val _ = cleanup
     }
   }
 

--- a/src/main/scala/tech/sourced/engine/iterator/CommitIterator.scala
+++ b/src/main/scala/tech/sourced/engine/iterator/CommitIterator.scala
@@ -28,7 +28,7 @@ class CommitIterator(finalColumns: Array[String],
                      repo: Repository,
                      prevIter: ReferenceIterator,
                      filters: Seq[CompiledFilter])
-  extends ChainableIterator[ReferenceWithCommit](finalColumns, prevIter, filters) {
+  extends ChainableIterator[ReferenceWithCommit](finalColumns, prevIter, filters, repo) {
 
   /** @inheritdoc*/
   override protected def loadIterator(filters: Seq[CompiledFilter]): Iterator[ReferenceWithCommit] =
@@ -154,13 +154,13 @@ private[iterator] class RefWithCommitIterator(repo: Repository,
             .call().asScala.toIterator
         } catch {
           case e: IncorrectObjectTypeException =>
-            log.debug(s"incorrect object found for ${repoInfo}", e)
+            log.debug(s"incorrect object found for ${RepositoryException.repoInfo(repo)}", e)
             null
           case e: MissingObjectException =>
-            log.warn(s"missing object for ${repoInfo}", e)
+            log.warn(s"missing object for ${RepositoryException.repoInfo(repo)}", e)
             null
           case e: RevWalkException =>
-            log.warn(s"rev walk error for ${repoInfo}", e)
+            log.warn(s"rev walk error for ${RepositoryException.repoInfo(repo)}", e)
             null
         }
     }
@@ -179,7 +179,7 @@ private[iterator] class RefWithCommitIterator(repo: Repository,
         true
       } catch {
         case e: RevWalkException =>
-          log.warn(s"rev walk error for ${repoInfo}", e)
+          log.warn(s"rev walk error for ${RepositoryException.repoInfo(repo)}", e)
           this.hasNext
       }
     } else {
@@ -200,13 +200,5 @@ private[iterator] class RefWithCommitIterator(repo: Repository,
     nextResult = null
     consumed += 1
     result
-  }
-
-  private def repoInfo(): String = {
-    val c = repo.getConfig
-    val remotes = c.getSubsections("remote").asScala
-    val urls = remotes.flatMap(r => c.getStringList("remote", r, "url"))
-
-    s"${repo.toString}; urls ${urls.mkString(", ")}"
   }
 }

--- a/src/main/scala/tech/sourced/engine/iterator/GitTreeEntryIterator.scala
+++ b/src/main/scala/tech/sourced/engine/iterator/GitTreeEntryIterator.scala
@@ -9,8 +9,9 @@ import tech.sourced.engine.util.{CompiledFilter, Filters}
 
 abstract class TreeEntryIterator(finalColumns: Array[String],
                                  prevIter: CommitIterator,
-                                 filters: Seq[CompiledFilter])
-  extends ChainableIterator[TreeEntry](finalColumns, prevIter, filters, prevIter.repo) {
+                                 filters: Seq[CompiledFilter],
+                                 repo: Repository)
+  extends ChainableIterator[TreeEntry](finalColumns, prevIter, filters, repo) {
 }
 
 /**
@@ -25,7 +26,7 @@ class GitTreeEntryIterator(finalColumns: Array[String],
                            repo: Repository,
                            prevIter: CommitIterator,
                            filters: Seq[CompiledFilter])
-  extends TreeEntryIterator(finalColumns, prevIter, filters) {
+  extends TreeEntryIterator(finalColumns, prevIter, filters, repo) {
 
   /** @inheritdoc*/
   override protected def loadIterator(filters: Seq[CompiledFilter]): Iterator[TreeEntry] =
@@ -58,7 +59,7 @@ class GitTreeEntryIterator(finalColumns: Array[String],
   */
 class MetadataTreeEntryIterator(finalColumns: Array[String],
                                 iter: Iterator[Map[String, Any]])
-  extends TreeEntryIterator(finalColumns, null, Seq()) {
+  extends TreeEntryIterator(finalColumns, null, Seq(), null) {
 
   // iter is converted to Iterator[TreeEntry] and mapColumns must receive a TreeEntry
   // in order to not lose all other columns that come from previous tables.

--- a/src/main/scala/tech/sourced/engine/iterator/GitTreeEntryIterator.scala
+++ b/src/main/scala/tech/sourced/engine/iterator/GitTreeEntryIterator.scala
@@ -10,7 +10,7 @@ import tech.sourced.engine.util.{CompiledFilter, Filters}
 abstract class TreeEntryIterator(finalColumns: Array[String],
                                  prevIter: CommitIterator,
                                  filters: Seq[CompiledFilter])
-  extends ChainableIterator[TreeEntry](finalColumns, prevIter, filters) {
+  extends ChainableIterator[TreeEntry](finalColumns, prevIter, filters, prevIter.repo) {
 }
 
 /**
@@ -45,7 +45,6 @@ class GitTreeEntryIterator(finalColumns: Array[String],
       "blob" -> obj.blob.getName
     )
   }
-
 }
 
 /**
@@ -157,9 +156,9 @@ object GitTreeEntryIterator extends Logging {
           }
         } catch {
           case e: IncorrectObjectTypeException =>
-            log.debug("incorrect object found", e)
+            log.debug(s"incorrect object found for ${RepositoryException.repoInfo(repo)}", e)
           case e: MissingObjectException =>
-            log.warn("missing object", e)
+            log.warn(s"missing object for ${RepositoryException.repoInfo(repo)}", e)
         }
 
         tree

--- a/src/main/scala/tech/sourced/engine/iterator/ReferenceIterator.scala
+++ b/src/main/scala/tech/sourced/engine/iterator/ReferenceIterator.scala
@@ -17,7 +17,7 @@ class ReferenceIterator(finalColumns: Array[String],
                         repo: Repository,
                         prevIter: RepositoryIterator,
                         filters: Seq[CompiledFilter])
-  extends ChainableIterator[Ref](finalColumns, prevIter, filters) {
+  extends ChainableIterator[Ref](finalColumns, prevIter, filters, repo) {
 
   /** @inheritdoc*/
   protected def loadIterator(filters: Seq[CompiledFilter]): Iterator[Ref] =
@@ -37,7 +37,6 @@ class ReferenceIterator(finalColumns: Array[String],
       "is_remote" -> RootedRepo.isRemote(repo, ref.getName)
     )
   }
-
 }
 
 object ReferenceIterator {

--- a/src/main/scala/tech/sourced/engine/iterator/RepositoryException.scala
+++ b/src/main/scala/tech/sourced/engine/iterator/RepositoryException.scala
@@ -1,0 +1,38 @@
+package tech.sourced.engine.iterator
+
+import org.eclipse.jgit.lib.Repository
+import scala.collection.JavaConverters.iterableAsScalaIterableConverter
+
+/**
+  * Exception to add repository debug information to any
+  * uncontrolled exception. It does not add a stacktrace level.
+  *
+  * @param repo Repository that was beeing iterated
+  * @param cause Original exception
+  */
+class RepositoryException(repo: Repository, cause: Throwable)
+    extends Exception(
+      s"Repository error with data: ${RepositoryException.repoInfo(repo)}",
+      cause,
+      true,
+      false) {}
+
+object RepositoryException {
+
+  /**
+    * Returns a string with a debug description of the repository
+    * @param repo Repository to describe
+    * @return
+    */
+  def repoInfo(repo: Repository): String = {
+    val c = repo.getConfig
+    val remotes = c.getSubsections("remote").asScala
+    val urls = remotes.flatMap(r => c.getStringList("remote", r, "url"))
+
+    if (urls.isEmpty) {
+      s"${repo.toString}"
+    } else {
+      s"${repo.toString}; urls ${urls.mkString(", ")}"
+    }
+  }
+}

--- a/src/main/scala/tech/sourced/engine/iterator/RepositoryException.scala
+++ b/src/main/scala/tech/sourced/engine/iterator/RepositoryException.scala
@@ -25,14 +25,19 @@ object RepositoryException {
     * @return
     */
   def repoInfo(repo: Repository): String = {
-    val c = repo.getConfig
-    val remotes = c.getSubsections("remote").asScala
-    val urls = remotes.flatMap(r => c.getStringList("remote", r, "url"))
+    try {
+      val c = repo.getConfig
+      val remotes = c.getSubsections("remote").asScala
+      val urls = remotes.flatMap(r => c.getStringList("remote", r, "url"))
 
-    if (urls.isEmpty) {
-      s"${repo.toString}"
-    } else {
-      s"${repo.toString}; urls ${urls.mkString(", ")}"
+      if (urls.isEmpty) {
+        s"${repo.toString}"
+      } else {
+        s"${repo.toString}; urls ${urls.mkString(", ")}"
+      }
+    } catch {
+      case e: Throwable =>
+        s"Exception in RepositoryException.repoInfo ${e.getMessage}"
     }
   }
 }

--- a/src/main/scala/tech/sourced/engine/iterator/RepositoryException.scala
+++ b/src/main/scala/tech/sourced/engine/iterator/RepositoryException.scala
@@ -25,19 +25,25 @@ object RepositoryException {
     * @return
     */
   def repoInfo(repo: Repository): String = {
+    val repoPath = try {
+      repo.toString
+    } catch {
+      case _: Throwable => "Unknown repository path"
+    }
+
     try {
       val c = repo.getConfig
       val remotes = c.getSubsections("remote").asScala
       val urls = remotes.flatMap(r => c.getStringList("remote", r, "url"))
 
       if (urls.isEmpty) {
-        s"${repo.toString}"
+        repoPath
       } else {
-        s"${repo.toString}; urls ${urls.mkString(", ")}"
+        s"$repoPath; urls ${urls.toSet.mkString(", ")}"
       }
     } catch {
       case e: Throwable =>
-        s"Exception in RepositoryException.repoInfo ${e.getMessage}"
+        s"Exception in RepositoryException.repoInfo for $repoPath: ${e.getMessage}"
     }
   }
 }

--- a/src/main/scala/tech/sourced/engine/iterator/RepositoryIterator.scala
+++ b/src/main/scala/tech/sourced/engine/iterator/RepositoryIterator.scala
@@ -15,7 +15,7 @@ class RepositoryIterator(repositoryPath: String,
                          finalColumns: Array[String],
                          repo: Repository,
                          filters: Seq[CompiledFilter])
-  extends ChainableIterator[String](finalColumns, null, filters) {
+  extends ChainableIterator[String](finalColumns, null, filters, repo) {
 
   // since this iterator does not override getFilters method of RootedRepository
   // we can cache here the matching cases, because they are not going to change.
@@ -41,7 +41,6 @@ class RepositoryIterator(repositoryPath: String,
       "repository_path" -> repositoryPath
     )
   }
-
 }
 
 object RepositoryIterator {


### PR DESCRIPTION
This PR is a proposal to add extra information when an untreated exception is caught in `CleanupIterator`.

The idea is that iterators can extend a new `CrashReporter` trait, and the global try/catch in `CleanupIterator` will check if the current iterator can add details to the exception.

Note: Each iterator will probably have extra useful debug details (maybe in `currentRow`?) that can be added later. I wanted to make this PR as simple as possible to request feedback.

Now the exceptions will look like this:
```
scala> engine.getRepositories.getReferences.getCommits.count()
[Stage 0:>                                                          (0 + 3) / 3]18/04/06 20:24:08 ERROR Executor: Exception in task 2.0 in stage 0.0 (TID 2)
java.lang.Exception: RefWithCommitIterator crashed for Repository[/tmp/spark-2465f2ae-b23a-429b-9d78-1529ccbd3852/processing-repositories/3605C2257CBB88D2A0F833494C945F93/13ffbec95ff31d0b0a2fb50e2e63145430a152da.siva]; urls https://github.com/angular/protractor, https://github.com/juliemr/protractor, https://github.com/juliemr/protractor, https://github.com/angular/protractor
	at tech.sourced.engine.iterator.CommitIterator.exceptionDetails(CommitIterator.scala:68)
	at tech.sourced.engine.iterator.CleanupIterator.hasNext(CleanupIterator.scala:31)
	at scala.collection.Iterator$$anon$12.hasNext(Iterator.scala:438)
	at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:408)
	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$GeneratedIterator.agg_doAggregateWithoutKey$(Unknown Source)
	at org.apache.spark.sql.catalyst.expressions.GeneratedClass$GeneratedIterator.processNext(Unknown Source)
	at org.apache.spark.sql.execution.BufferedRowIterator.hasNext(BufferedRowIterator.java:43)
	at org.apache.spark.sql.execution.WholeStageCodegenExec$$anonfun$8$$anon$1.hasNext(WholeStageCodegenExec.scala:395)
	at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:408)
	at org.apache.spark.shuffle.sort.BypassMergeSortShuffleWriter.write(BypassMergeSortShuffleWriter.java:125)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:96)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:53)
	at org.apache.spark.scheduler.Task.run(Task.scala:108)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:335)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.Exception: Forced exception for testing
	at tech.sourced.engine.iterator.RefWithCommitIterator.hasNext(CommitIterator.scala:147)
	at tech.sourced.engine.iterator.ChainableIterator.hasNext(ChainableIterator.scala:89)
	at org.apache.spark.InterruptibleIterator.hasNext(InterruptibleIterator.scala:37)
	at tech.sourced.engine.iterator.CleanupIterator.hasNext(CleanupIterator.scala:23)
	... 15 more
```