### PR TITLE
iterator: traverse all commits when iterator is not chained

### DIFF
--- a/src/main/scala/tech/sourced/engine/iterator/CommitIterator.scala
+++ b/src/main/scala/tech/sourced/engine/iterator/CommitIterator.scala
@@ -98,11 +98,12 @@ object CommitIterator {
       )
     }
 
+    val isChained = ref.isDefined
     val hashKeys = Seq("hash", hashKey)
     var iter: Iterator[ReferenceWithCommit] = new RefWithCommitIterator(
       repo,
       refs,
-      if (!filters.hasFilters("index")) 1 else 0
+      if (isChained && !filters.hasFilters("index")) 1 else 0
     )
 
     if (filters.hasFilters(hashKeys: _*)) {
@@ -147,6 +148,7 @@ private[iterator] class RefWithCommitIterator(repo: Repository,
     while ((commits == null || !commits.hasNext) && refs.hasNext) {
       actualRef = refs.next()
       index = 0
+      consumed = 0
       commits =
         try {
           Git.wrap(repo).log()

--- a/src/test/scala/tech/sourced/engine/DefaultSourceSpec.scala
+++ b/src/test/scala/tech/sourced/engine/DefaultSourceSpec.scala
@@ -64,6 +64,14 @@ class DefaultSourceSpec extends BaseSourceSpec("DefaultSource") {
     Engine(ss, tmpPath.toString, "standard").getRepositories.getHEAD.count() should be(1)
   }
 
+  it should "traverse all commits if it's not chained" in {
+    val row = engine.session.sql("SELECT COUNT(*) FROM commits").first()
+    row(0) should be(18107)
+
+    val row2 = engine.session.sql("SELECT COUNT(*) FROM commits WHERE index > 0").first()
+    row2(0) should be(18058)
+  }
+
   override protected def afterAll(): Unit = {
     super.afterAll()
 


### PR DESCRIPTION
Fixes #368 