### PR TITLE
python: require 2.2.x pyspark instead of >= 2.0.0

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,1 +1,1 @@
-pyspark==2.2.1
+pyspark==2.2.0.post0

--- a/python/setup.py
+++ b/python/setup.py
@@ -26,7 +26,7 @@ setup(
     url="https://github.com/src-d/engine/tree/master/python",
     packages=['sourced.engine'],
     namespace_packages=['sourced'],
-    install_requires=["pyspark>=2.0.0"],
+    install_requires=["pyspark==2.2.0.post0"],
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",
         "Intended Audience :: Developers",


### PR DESCRIPTION
Fixes #378 