### PR TITLE
Change log level for closing repository message

### DIFF
--- a/src/main/scala/tech/sourced/engine/provider/RepositoryProvider.scala
+++ b/src/main/scala/tech/sourced/engine/provider/RepositoryProvider.scala
@@ -87,7 +87,7 @@ class RepositoryProvider(val localPath: String,
     if (repositoryPool.getNumActive(key) != 0) {
       repositoryPool.returnObject(key, repo)
     } else {
-      logWarning(s"closing repository at ${repo.getDirectory};" +
+      logDebug(s"closing repository at ${repo.getDirectory};" +
         s" returning object to the pool failed because it was already returned")
     }
 


### PR DESCRIPTION
After https://github.com/src-d/engine/pull/380/files we call `close()` method on `TaskCompletion` and also call it on `destroyObject`. It causes unnecessary warnings. According to code, it expected behavior now and shouldn't be a warning.

Steps to reproduce:
```
> import tech.sourced.engine._
> val engine = Engine(spark, "/Users/smacker/Work/gemini/src/test/resources/siva", "siva")
> val r = engine.getRepositories.getHEAD.getCommits.getTreeEntries.getBlobs.filter('is_binary === false).cache()
> r.show()

18/05/07 12:59:14 WARN RepositoryProvider: closing repository at /private/var/folders/qq/2hysx6wj34d040mcby284j300000gn/T/spark-bb7cd59a-8173-4dc9-8436-077b3ae6c794/processing-repositories/E4236CDEBF2574B13D4381645209F7B8/2636f3c62f1a407b2996da6e3fe6fdc5d1ccd764.siva; returning object to the pool failed because it was already returned
```