### PR TITLE
Update PySpark version

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,2 +1,2 @@
-pyspark==2.2.0.post0
+pyspark>=2.2.0,<2.2.1
 bblfsh==2.9.10

--- a/python/setup.py
+++ b/python/setup.py
@@ -26,7 +26,7 @@ setup(
     url="https://github.com/src-d/engine/tree/master/python",
     packages=['sourced.engine'],
     namespace_packages=['sourced'],
-    install_requires=["pyspark==2.2.0.post0"],
+    install_requires=["pyspark>=2.2.0,<2.2.1"],
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",
         "Intended Audience :: Developers",


### PR DESCRIPTION
Since I got no responses, did PR to solve [this issue](https://github.com/src-d/engine/issues/390).
**TL;DR:** The `pyspark` version we use is marked as `2.2.0` once installed, but `2.2.0.post0` in PyPi, which leads to reinstalling `pyspark` at each upgrade/install of the engine, even if the correct spark is already present. This will remove that behavior.