### PR TITLE
Log line cleanup: `SparMetric` to `SparkMetric`

### DIFF
--- a/src/main/scala/tech/sourced/engine/udf/CustomUDF.scala
+++ b/src/main/scala/tech/sourced/engine/udf/CustomUDF.scala
@@ -29,7 +29,7 @@ sealed class SparkTimerUDFWrapper(name: String) extends Logging {
       UserMetricsSystem.timer(name)
     } catch {
       case _: NotInitializedException => {
-        logWarning("SparMetric not initialized on UDF")
+        logWarning("SparkMetric not initialized on UDF")
         null
       }
     }


### PR DESCRIPTION
Noticed this while reading through your code.