### PR TITLE
Fix tests to make them work with new bblfsh driver version

### DIFF
--- a/python/test/test_engine.py
+++ b/python/test/test_engine.py
@@ -187,7 +187,7 @@ class EngineTestCase(BaseTestCase):
                 node = parse_uast_node(node)
                 idents.append(node.token)
 
-        self.assertEqual(idents, ["contents", "read", "f", "open", "f"])
+        self.assertCountEqual(idents, ["contents", "read", "f", "open", "f"])
 
 
     def test_uast_query_cols(self):
@@ -206,7 +206,7 @@ class EngineTestCase(BaseTestCase):
                 node = parse_uast_node(node)
                 idents.append(node.token)
 
-        self.assertEqual(idents, ["contents", "read", "f", "open", "f"])
+        self.assertCountEqual(idents, ["contents", "read", "f", "open", "f"])
 
 
     def test_extract_tokens(self):
@@ -216,7 +216,7 @@ class EngineTestCase(BaseTestCase):
         row = df.extract_uasts().query_uast('//*[@roleIdentifier and not(@roleIncomplete)]')\
             .extract_tokens().first()
 
-        self.assertEqual(row["tokens"], ["contents", "read", "f", "open", "f"])
+        self.assertCountEqual(row["tokens"], ["contents", "read", "f", "open", "f"])
 
     def test_metadata(self):
         tmpdir = tempfile.mkdtemp()

--- a/src/test/scala/tech/sourced/engine/udf/CustomUDFSpec.scala
+++ b/src/test/scala/tech/sourced/engine/udf/CustomUDFSpec.scala
@@ -120,13 +120,12 @@ class CustomUDFSpec extends FlatSpec with Matchers with BaseSparkSpec {
       .filter(!_.roles.contains(Role.INCOMPLETE))
 
     nodes.length should be(5)
-    nodes.map(_.token) should equal(Seq(
+    nodes.map(_.token) should contain allOf(
       "contents",
       "read",
-      "f",
       "open",
       "f"
-    ))
+    )
   }
 
   it should "query using queryUAST method of dataframe" in {
@@ -144,13 +143,12 @@ class CustomUDFSpec extends FlatSpec with Matchers with BaseSparkSpec {
       .map(_.token)
 
     identifiers.length should be(5)
-    identifiers should equal(Seq(
+    identifiers should contain allOf(
       "contents",
       "read",
-      "f",
       "open",
       "f"
-    ))
+    )
   }
 
   it should "query using queryUAST method of dataframe with custom cols" in {
@@ -169,13 +167,12 @@ class CustomUDFSpec extends FlatSpec with Matchers with BaseSparkSpec {
       .map(_.token)
 
     identifiers.length should be(5)
-    identifiers should equal(Seq(
+    identifiers should contain allOf(
       "contents",
       "read",
-      "f",
       "open",
       "f"
-    ))
+    )
   }
 
   "ExtractTokensUDF" should "extract the tokens in a column" in {
@@ -192,13 +189,12 @@ class CustomUDFSpec extends FlatSpec with Matchers with BaseSparkSpec {
       .flatMap(_.asInstanceOf[Seq[String]])
 
     identifiers.length should be(5)
-    identifiers should equal(Seq(
+    identifiers should contain allOf(
       "contents",
       "read",
-      "f",
       "open",
       "f"
-    ))
+    )
   }
 
 }


### PR DESCRIPTION
Bblfsh python driver version 2.0.0 changes the order of nodes on his output. To make tests pass, we need to check the content of the output but not the order.

Signed-off-by: Antonio Jesus Navarro Perez <antnavper@gmail.com>