### PR TITLE
add support for Apache Spark 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,7 @@ dist: trusty
 sudo: required
 
 language: scala
-
-scala:
-   - 2.11.11
+scala: 2.11.11
 
 cache:
   directories:
@@ -14,13 +12,46 @@ cache:
 services:
   - docker
 
-matrix:
-  fast_finish: true
-  include:
-    - jdk: jdk8
+install:
+  - |
+    set -e
+    if [[ ${LANGUAGE} = python ]]; then
+      sudo apt install libxml2-dev curl build-essential
+      make build
+      cd python
+      pip install -e .
+    fi
 
-      after_success:
-        - bash <(curl -s https://codecov.io/bash)
+before_script:
+  - make -f "$TRAVIS_BUILD_DIR/Makefile" docker-bblfsh
+  - make -f "$TRAVIS_BUILD_DIR/Makefile" docker-bblfsh-install-drivers
+
+script:
+  - if [[ ${LANGUAGE} = python ]]; then make test ;fi
+  - |
+    set -e
+    if [[ ${LANGUAGE} = java ]]; then
+      make travis-test
+      bash <(curl -s https://codecov.io/bash)
+    fi
+
+jobs:
+  include:
+    - {env: 'LANGUAGE=java   SPARK_VERSION=2.2.1', jdk: openjdk8}
+    - {env: 'LANGUAGE=java   SPARK_VERSION=2.3.1', jdk: openjdk8}
+    - {env: 'LANGUAGE=python SPARK_VERSION=2.3.1', python: 3.4, language: python}
+    - {env: 'LANGUAGE=python SPARK_VERSION=2.3.1', python: 3.5, language: python}
+    - {env: 'LANGUAGE=python SPARK_VERSION=2.2.1', python: 3.6, language: python}
+    - {env: 'LANGUAGE=python SPARK_VERSION=2.3.1', python: 3.6, language: python}
+
+    - stage: deploy
+      if: tag IS present OR (branch = master AND env(TRAVIS_PULL_REQUEST) IS present)
+      jdk: openjdk8
+
+      install: skip
+      before_script: skip
+
+      script:
         - openssl aes-256-cbc -K $encrypted_8a9ac81f2640_key -iv $encrypted_8a9ac81f2640_iv -in key.asc.enc -out key.asc -d
         - gpg --no-default-keyring --primary-keyring ./project/.gnupg/pubring.gpg --secret-keyring ./project/.gnupg/secring.gpg --keyring ./project/.gnupg/pubring.gpg --fingerprint --import key.asc
         - make build
@@ -42,45 +73,15 @@ matrix:
           on:
             tags: true
 
-    - jdk: openjdk8
-
-    - language: python
-      python: 3.4
-
-      install:
-        - sudo apt install libxml2-dev curl build-essential
-        - make build
-        - cd python
-        - pip install -e .
-
-      script:
-        - make test
-
-    - language: python
-      python: 3.5
-
-      install:
-        - sudo apt install libxml2-dev curl build-essential
-        - make build
-        - cd python
-        - pip install -e .
-
-      script:
-        - make test
-
-    - language: python
+    - if: tag IS present
+      language: python
       python: 3.6
 
-      install:
+      script:
         - sudo apt install libxml2-dev curl build-essential
         - make build
         - cd python
         - pip install -e .
-
-      script:
-        - make test
-
-      before_deploy:
         - echo "$TRAVIS_TAG" | cut -c 2- > version.txt
 
       deploy:
@@ -90,10 +91,3 @@ matrix:
           skip_cleanup: true
           on:
             tags: true
-
-before_script:
-  - make -f "$TRAVIS_BUILD_DIR/Makefile" docker-bblfsh
-  - make -f "$TRAVIS_BUILD_DIR/Makefile" docker-bblfsh-install-drivers
-
-script:
-  - make travis-test

--- a/Makefile
+++ b/Makefile
@@ -74,8 +74,9 @@ JUPYTER_RUN_FLAGS := --name $(JUPYTER_CONTAINER_NAME) --rm -it \
 	--link $(BBLFSH_CONTAINER_NAME):$(BBLFSH_CONTAINER_NAME) \
 	$(call unescape_docker_tag,$(JUPYTER_IMAGE_VERSIONED))
 
-# Scala version
+# Versions
 SCALA_VERSION ?= 2.11.11
+SPARK_VERSION ?= 2.2.1
 
 # if TRAVIS_SCALA_VERSION defined SCALA_VERSION is overrided
 ifneq ($(TRAVIS_SCALA_VERSION), )
@@ -100,7 +101,7 @@ ifneq ($(TRAVIS_PULL_REQUEST), false)
 endif
 
 #SBT
-SBT = ./sbt ++$(SCALA_VERSION)
+SBT = ./sbt ++$(SCALA_VERSION) -Dspark.version=$(SPARK_VERSION)
 
 # Rules
 all: clean build

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Either in case the `LANG` variable wouldn't be set to a UTF-8 encoding or it wou
 
 * Scala 2.11.x
 * Python >= 3.4.x (engine is tested with Python 3.4, 3.5 and 3.6 and these are the supported versions, even if it might still work with previous ones)
-* [Apache Spark Installation](http://spark.apache.org/docs/2.2.1/) 2.2.x (recommended) or 2.3.x
+* [Apache Spark Installation](http://spark.apache.org/docs/2.2.1/) 2.2.x or 2.3.x
 * [bblfsh](https://github.com/bblfsh/bblfshd) >= 2.5.0: Used for UAST extraction
 
 # Examples of engine usage

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Either in case the `LANG` variable wouldn't be set to a UTF-8 encoding or it wou
 
 * Scala 2.11.x
 * Python >= 3.4.x (engine is tested with Python 3.4, 3.5 and 3.6 and these are the supported versions, even if it might still work with previous ones)
-* [Apache Spark Installation](http://spark.apache.org/docs/2.2.1/) 2.2.x
+* [Apache Spark Installation](http://spark.apache.org/docs/2.2.1/) 2.2.x (recommended) or 2.3.x
 * [bblfsh](https://github.com/bblfsh/bblfshd) >= 2.5.0: Used for UAST extraction
 
 # Examples of engine usage

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,9 +1,12 @@
 import sbt._
 
 object Dependencies {
+  lazy val sparkVersion: String = sys.props.get("spark.version")
+    .getOrElse("2.2.1")
+
   lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.0.1"
   lazy val scoverage = "org.scoverage" %% "scalac-scoverage-plugin" % "1.3.1"
-  lazy val sparkSql = "org.apache.spark" %% "spark-sql" % "2.2.1"
+  lazy val sparkSql = "org.apache.spark" %% "spark-sql" % sparkVersion
   lazy val newerHadoopClient = "org.apache.hadoop" % "hadoop-client" % "2.7.2"
   lazy val fixNettyForGrpc = "io.netty" % "netty-all" % "4.1.17.Final"
   lazy val jgit = "org.eclipse.jgit" % "org.eclipse.jgit" % "4.9.0.201710071750-r"

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,5 +1,6 @@
 from __future__ import with_statement
 from setuptools import setup
+import os
 from os.path import exists, join, dirname, realpath
 
 CURR_DIR = dirname(realpath(__file__))
@@ -26,7 +27,10 @@ setup(
     url="https://github.com/src-d/engine/tree/master/python",
     packages=['sourced.engine'],
     namespace_packages=['sourced'],
-    install_requires=["pyspark==2.2.1","bblfsh==2.9.13"],
+    install_requires=[
+        "pyspark==" + os.environ.get('SPARK_VERSION', "2.2.1"),
+        "bblfsh==2.9.13"
+    ],
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",
         "Intended Audience :: Developers",

--- a/src/main/scala/tech/sourced/engine/compat/compat.scala
+++ b/src/main/scala/tech/sourced/engine/compat/compat.scala
@@ -1,0 +1,76 @@
+package tech.sourced.engine.compat
+
+import org.apache.spark.SPARK_VERSION
+import org.apache.spark.sql.catalyst.catalog.CatalogTable
+import org.apache.spark.sql.catalyst.expressions.AttributeReference
+import org.apache.spark.sql.execution.datasources.{
+  LogicalRelation => SparkLogicalRelation
+}
+import org.apache.spark.sql.sources.BaseRelation
+
+import scala.reflect.runtime.{universe => ru}
+
+private[compat] object Compat {
+
+  def apply[T](s22: T, s23: T): T = SPARK_VERSION match {
+    case s if s.startsWith("2.2.") => s22
+    case s if s.startsWith("2.3.") => s23
+    case _ =>
+      throw new RuntimeException(s"Unsupported SPARK_VERSION: $SPARK_VERSION")
+  }
+
+  lazy val ClassMirror = ru.runtimeMirror(Compat.getClass.getClassLoader)
+
+}
+
+private[engine] object LogicalRelation {
+
+  def apply(rel: BaseRelation,
+            out: Seq[AttributeReference],
+            catalog: Option[CatalogTable]): SparkLogicalRelation =
+    applyImpl(rel, out, catalog)
+
+  private lazy val applyImpl =
+    Compat(applySpark22(_, _, _), applySpark23(_, _, _))
+
+  private lazy val typ = ru.typeOf[SparkLogicalRelation]
+  private lazy val classSymbol =
+    Compat.ClassMirror.reflectClass(typ.typeSymbol.asClass)
+  private lazy val ctor =
+    classSymbol.reflectConstructor(typ.decl(ru.termNames.CONSTRUCTOR).asMethod)
+
+  def applySpark22(rel: BaseRelation,
+                   out: Seq[AttributeReference],
+                   catalog: Option[CatalogTable]): SparkLogicalRelation =
+    ctor(rel, out, catalog).asInstanceOf[SparkLogicalRelation]
+
+  def applySpark23(rel: BaseRelation,
+                   out: Seq[AttributeReference],
+                   catalog: Option[CatalogTable]): SparkLogicalRelation =
+    ctor(rel, out, catalog, false).asInstanceOf[SparkLogicalRelation]
+
+  def unapply(arg: SparkLogicalRelation)
+    : Option[(BaseRelation, Seq[AttributeReference], Option[CatalogTable])] =
+    unapplyImpl(arg)
+
+  private lazy val unapplyImpl = Compat(unapplySpark22(_), unapplySpark23(_))
+
+  def unapplySpark22(arg: SparkLogicalRelation)
+    : Option[(BaseRelation, Seq[AttributeReference], Option[CatalogTable])] =
+    Some((arg.relation, arg.output, arg.catalogTable))
+
+  def unapplySpark23(arg: SparkLogicalRelation)
+    : Option[(BaseRelation, Seq[AttributeReference], Option[CatalogTable])] = {
+    val isStreaming = Compat.ClassMirror
+      .reflect(arg)
+      .reflectField(typ.decl(ru.TermName("isStreaming")).asTerm)
+      .get
+      .asInstanceOf[Boolean]
+    if (isStreaming) {
+      None
+    } else {
+      Some((arg.relation, arg.output, arg.catalogTable))
+    }
+  }
+
+}

--- a/src/main/scala/tech/sourced/engine/rule/AddSourceToAttributes.scala
+++ b/src/main/scala/tech/sourced/engine/rule/AddSourceToAttributes.scala
@@ -8,6 +8,7 @@ import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.apache.spark.sql.sources.BaseRelation
 import org.apache.spark.sql.types.MetadataBuilder
 import tech.sourced.engine.{GitRelation, MetadataRelation, Sources}
+import tech.sourced.engine.compat
 
 /**
   * Rule to assign to an [[AttributeReference]] metadata to identify the table it belongs to.
@@ -21,10 +22,15 @@ object AddSourceToAttributes extends Rule[LogicalPlan] {
 
   /** @inheritdoc */
   def apply(plan: LogicalPlan): LogicalPlan = plan transformUp {
-    case LogicalRelation(rel@GitRelation(_, _, _, schemaSource), out, catalogTable) =>
+    case compat.LogicalRelation(rel @ GitRelation(_, _, _, schemaSource),
+                                out,
+                                catalogTable) =>
       withMetadata(rel, schemaSource, out, catalogTable)
 
-    case LogicalRelation(rel@MetadataRelation(_, _, _, _, schemaSource), out, catalogTable) =>
+    case compat.LogicalRelation(
+        rel @ MetadataRelation(_, _, _, _, schemaSource),
+        out,
+        catalogTable) =>
       withMetadata(rel, schemaSource, out, catalogTable)
   }
 
@@ -40,7 +46,7 @@ object AddSourceToAttributes extends Rule[LogicalPlan] {
       case None => out
     }
 
-    LogicalRelation(relation, processedOut, catalogTable)
+    compat.LogicalRelation(relation, processedOut, catalogTable)
   }
 
 }

--- a/src/main/scala/tech/sourced/engine/rule/SquashMetadataRelationsJoin.scala
+++ b/src/main/scala/tech/sourced/engine/rule/SquashMetadataRelationsJoin.scala
@@ -8,6 +8,7 @@ import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.datasources.LogicalRelation
 import tech.sourced.engine.{GitRelation, MetadataRelation}
+import tech.sourced.engine.compat
 
 object SquashMetadataRelationsJoin extends Rule[LogicalPlan] {
   /** @inheritdoc */
@@ -28,7 +29,7 @@ object SquashMetadataRelationsJoin extends Rule[LogicalPlan] {
         Some(dbPath),
         _
         ) =>
-          val relation = LogicalRelation(
+          val relation = compat.LogicalRelation(
             MetadataRelation(
               session,
               RelationOptimizer.attributesToSchema(attributes),
@@ -122,7 +123,7 @@ private[rule] object MetadataOptimizer extends Logging {
         MetadataJoinData(Some(cond), valid = true)
       case Project(namedExpressions, _) =>
         MetadataJoinData(None, projectExpressions = namedExpressions, valid = true)
-      case LogicalRelation(MetadataRelation(session, _, dbPath, joinCondition, _), out, _) =>
+      case compat.LogicalRelation(MetadataRelation(session, _, dbPath, joinCondition, _), out, _) =>
         MetadataJoinData(
           None,
           valid = true,
@@ -131,7 +132,7 @@ private[rule] object MetadataOptimizer extends Logging {
           session = Some(session),
           dbPath = Some(dbPath)
         )
-      case LogicalRelation(GitRelation(session, _, joinCondition, _), out, _) =>
+      case compat.LogicalRelation(GitRelation(session, _, joinCondition, _), out, _) =>
         MetadataJoinData(
           None,
           valid = true,
@@ -182,8 +183,8 @@ private[rule] object MetadataOptimizer extends Logging {
 
   def getRelation(lp: LogicalPlan): Option[LogicalRelation] =
     lp.find {
-      case LogicalRelation(_: MetadataRelation, _, _) => true
-      case LogicalRelation(GitRelation(_, _, _, Some("blobs")), _, _) => true
+      case compat.LogicalRelation(_: MetadataRelation, _, _) => true
+      case compat.LogicalRelation(GitRelation(_, _, _, Some("blobs")), _, _) => true
       case _ => false
     } map (_.asInstanceOf[LogicalRelation])
 


### PR DESCRIPTION
- A new private package `compat` is added with compatibility shims.

- Shims for apply/unapply on LogicalRelation are added with compatibility
  with Spark 2.2.x and 2.3.x.

- If an unsupported Spark version is used, a human-readable exception is thrown.
