### PR TITLE
Fix Engine init settings

### DIFF
--- a/_examples/notebooks/Example.ipynb
+++ b/_examples/notebooks/Example.ipynb
@@ -21,7 +21,7 @@
     ".master(\"local[*]\").appName(\"Examples\")\\\n",
     ".getOrCreate()\n",
     "\n",
-    "engine = Engine(spark, \"/repositories\", \"standard\")\n",
+    "engine = Engine(spark, \"/repositories\", \"siva\")\n",
     "\n",
     "print(\"%d repositories successfully loaded\" % (engine.repositories.count()/2))"
    ]


### PR DESCRIPTION
This PR fixes a simple bug I found when running the notebook on the engine docker image. Basically, the command:

```
engine = Engine(spark, "/repositories", "standard")
```

Failed with the error:

```
Py4JJavaError: An error occurred while calling o302.count.
: org.apache.hadoop.mapreduce.lib.input.InvalidInputException: Input Pattern file:/repositories/**/* matches 0 files
```
Which I  assume it has to do with the expected structure of the repositories.

Replacing that line with:

```
engine = Engine(spark, "/repositories", "siva")
```


Fixed it.