### PR TITLE
Increases context timeout from 10 to 1440 minutes

### DIFF
--- a/cmd/srcd/cmd/sql.go
+++ b/cmd/srcd/cmd/sql.go
@@ -111,7 +111,7 @@ func runQuery(query string) error {
 	}
 
 	// Might have to pull some images
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 1440*time.Minute)
 	defer cancel()
 
 	res, err := c.SQL(ctx, &api.SQLRequest{Query: query})


### PR DESCRIPTION
Sorry for merging directly, feel free to revert but we can't have queries timeout after 10 mins.

Signed-off-by: Eiso Kant <eiso@sourced.tech>