### PR TITLE
Kill: don't remove images by default

### DIFF
--- a/cmd/srcd/cmd/kill.go
+++ b/cmd/srcd/cmd/kill.go
@@ -8,9 +8,11 @@ import (
 
 var killCmd = &cobra.Command{
 	Use:   "kill",
-	Short: "Stops and removes all containers, volumes and docker images used by engine.",
+	Short: "Stops and removes all containers and volumes used by engine.",
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := components.Purge(); err != nil {
+		withImages, _ := cmd.Flags().GetBool("with-images")
+
+		if err := components.Purge(withImages); err != nil {
 			logrus.Fatal(err)
 		}
 	},
@@ -18,4 +20,6 @@ var killCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(killCmd)
+
+	killCmd.Flags().Bool("with-images", false, "remove docker images")
 }

--- a/components/components.go
+++ b/components/components.go
@@ -142,7 +142,7 @@ func IsInstalled(ctx context.Context, id string) (bool, error) {
 	return docker.IsInstalled(ctx, image, version)
 }
 
-func Purge() error {
+func Purge(images bool) error {
 	logrus.Info("removing containers...")
 	if err := removeContainers(); err != nil {
 		return errors.Wrap(err, "unable to remove all containers")
@@ -154,10 +154,12 @@ func Purge() error {
 		return errors.Wrap(err, "unable to remove volumes")
 	}
 
-	logrus.Info("removing images...")
+	if images {
+		logrus.Info("removing images...")
 
-	if err := removeImages(); err != nil {
-		return errors.Wrap(err, "unable to remove all images")
+		if err := removeImages(); err != nil {
+			return errors.Wrap(err, "unable to remove all images")
+		}
 	}
 
 	return nil

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -47,11 +47,12 @@ directory if none is given.
 
 ## srcd kill
 
-Removes all containers, docker images and docker volumes used by the source{d} engine.
+Removes all containers and docker volumes used by the source{d} engine.
 
 *arguments*: N/A
 
-*flags*: N/A
+*flags*:
+  * `--with-images`: remove docker images too
 
 *status*: ✅ implemented
 


### PR DESCRIPTION
Fix: #61 #69

As described in the issue the current behavior is very strange.
This PR changes the default. `srcd kill` won't remove images anymore by default. But only with new flag `--with-images`