### PR TITLE
Remove go tip from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,9 @@ go_import_path: github.com/src-d/engine
 
 go:
   - 1.11.x
-  - tip
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - go: tip
 
 addons:
   apt:


### PR DESCRIPTION
Follow update to CI guide: https://github.com/src-d/guide/pull/276