### PR TITLE
remove network on purge

### DIFF
--- a/components/components.go
+++ b/components/components.go
@@ -150,6 +150,12 @@ func Purge(images bool) error {
 		return errors.Wrap(err, "unable to remove volumes")
 	}
 
+	logrus.Info("removing network...")
+
+	if err := docker.RemoveNetwork(context.Background()); err != nil {
+		return errors.Wrap(err, "unable to remove network")
+	}
+
 	if images {
 		logrus.Info("removing images...")
 

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -354,9 +354,9 @@ func RemoveImage(ctx context.Context, id string) error {
 	return err
 }
 
-func connectToNetwork(ctx context.Context, containerID string) error {
-	const networkName = "srcd-cli-network"
+const networkName = "srcd-cli-network"
 
+func connectToNetwork(ctx context.Context, containerID string) error {
 	c, err := client.NewEnvClient()
 	if err != nil {
 		return errors.Wrap(err, "could not create docker client")
@@ -371,4 +371,21 @@ func connectToNetwork(ctx context.Context, containerID string) error {
 		}
 	}
 	return c.NetworkConnect(ctx, networkName, containerID, nil)
+}
+
+func RemoveNetwork(ctx context.Context) error {
+	c, err := client.NewEnvClient()
+	if err != nil {
+		return errors.Wrap(err, "could not create docker client")
+	}
+
+	resp, err := c.NetworkInspect(ctx, networkName)
+	if client.IsErrNetworkNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return errors.Wrap(err, "could not inspect network")
+	}
+
+	return c.NetworkRemove(ctx, resp.ID)
 }


### PR DESCRIPTION
Fix #62

it removes the network. Renaming/splitting of the kill command should be handled in a separate issue.