### PR TITLE
Pass context around

### DIFF
--- a/cmd/srcd-server/engine/drivers.go
+++ b/cmd/srcd-server/engine/drivers.go
@@ -17,8 +17,8 @@ import (
 
 var ErrDriverAlreadyInstalled = errors.New("driver already installed")
 
-func (s *Server) bblfshDriverClient() (drivers.ProtocolServiceClient, error) {
-	if err := s.startComponent(bblfshd.Name); err != nil {
+func (s *Server) bblfshDriverClient(ctx context.Context) (drivers.ProtocolServiceClient, error) {
+	if err := s.startComponent(ctx, bblfshd.Name); err != nil {
 		return nil, err
 	}
 
@@ -33,7 +33,7 @@ func (s *Server) bblfshDriverClient() (drivers.ProtocolServiceClient, error) {
 }
 
 func (s *Server) ListDrivers(ctx context.Context, req *api.ListDriversRequest) (*api.ListDriversResponse, error) {
-	client, err := s.bblfshDriverClient()
+	client, err := s.bblfshDriverClient(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +58,7 @@ func (s *Server) InstallDriver(
 	ctx context.Context,
 	r *api.VersionedDriver,
 ) (*api.InstallDriverResponse, error) {
-	client, err := s.bblfshDriverClient()
+	client, err := s.bblfshDriverClient(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -71,7 +71,7 @@ func (s *Server) UpdateDriver(
 	ctx context.Context,
 	r *api.VersionedDriver,
 ) (*api.UpdateDriverResponse, error) {
-	client, err := s.bblfshDriverClient()
+	client, err := s.bblfshDriverClient(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +84,7 @@ func (s *Server) RemoveDriver(
 	ctx context.Context,
 	r *api.RemoveDriverRequest,
 ) (*api.RemoveDriverResponse, error) {
-	client, err := s.bblfshDriverClient()
+	client, err := s.bblfshDriverClient(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +113,7 @@ func getOfficialDrivers() ([]discovery.Driver, error) {
 	return driverCache.List, err
 }
 
-func (s *Server) installStableDrivers() error {
+func (s *Server) installStableDrivers(ctx context.Context) error {
 	logrus.Info("installing all recommended drivers")
 
 	drivers, err := getOfficialDrivers()
@@ -121,7 +121,7 @@ func (s *Server) installStableDrivers() error {
 		return err
 	}
 
-	client, err := s.bblfshDriverClient()
+	client, err := s.bblfshDriverClient(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/srcd-server/engine/sql.go
+++ b/cmd/srcd-server/engine/sql.go
@@ -27,7 +27,7 @@ var (
 )
 
 func (s *Server) SQL(ctx context.Context, req *api.SQLRequest) (*api.SQLResponse, error) {
-	err := s.startComponent(gitbase.Name)
+	err := s.startComponent(ctx, gitbase.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +75,7 @@ func (s *Server) SQL(ctx context.Context, req *api.SQLRequest) (*api.SQLResponse
 }
 
 func createGitbase(opts ...docker.ConfigOption) docker.StartFunc {
-	return func() error {
+	return func(ctx context.Context) error {
 		if err := docker.EnsureInstalled(gitbase.Image, ""); err != nil {
 			return err
 		}

--- a/cmd/srcd-server/engine/web.go
+++ b/cmd/srcd-server/engine/web.go
@@ -23,7 +23,7 @@ var (
 )
 
 func createBblfshWeb(opts ...docker.ConfigOption) docker.StartFunc {
-	return func() error {
+	return func(ctx context.Context) error {
 		if err := docker.EnsureInstalled(bblfshWeb.Image, ""); err != nil {
 			return err
 		}
@@ -50,7 +50,7 @@ func createBblfshWeb(opts ...docker.ConfigOption) docker.StartFunc {
 }
 
 func createGitbaseWeb(opts ...docker.ConfigOption) docker.StartFunc {
-	return func() error {
+	return func(ctx context.Context) error {
 		if err := docker.EnsureInstalled(gitbaseWeb.Image, ""); err != nil {
 			return err
 		}

--- a/cmd/srcd/daemon/daemon.go
+++ b/cmd/srcd/daemon/daemon.go
@@ -91,6 +91,7 @@ func start(workdir string) (*docker.Container, error) {
 	}
 
 	return docker.InfoOrStart(
+		context.Background(),
 		daemonName,
 		createDaemon(workdir, datadir),
 	)
@@ -114,7 +115,7 @@ func setupDataDirectory(workdir, datadir string) error {
 }
 
 func createDaemon(workdir, datadir string) docker.StartFunc {
-	return func() error {
+	return func(ctx context.Context) error {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -264,15 +264,15 @@ func ApplyOptions(c *container.Config, hc *container.HostConfig, opts ...ConfigO
 	}
 }
 
-type StartFunc func() error
+type StartFunc func(ctx context.Context) error
 
-func InfoOrStart(name string, start StartFunc) (*Container, error) {
+func InfoOrStart(ctx context.Context, name string, start StartFunc) (*Container, error) {
 	i, err := Info(name)
 	if err == nil {
 		return i, nil
 	}
 
-	if err := start(); err != nil {
+	if err := start(ctx); err != nil {
 		return nil, errors.Wrapf(err, "could not create %s", name)
 	}
 


### PR DESCRIPTION
We will need to pass request id around for logs and it can be useful for some other improvements later.

Extracted from #88
