### PR TITLE
Fix container dependencies for init cmd

### DIFF
--- a/cmd/srcd/cmd/components.go
+++ b/cmd/srcd/cmd/components.go
@@ -42,15 +42,22 @@ var componentsListCmd = &cobra.Command{
 			return err
 		}
 
-		imgs, err := components.List(
+		cmps, err := components.List(
 			context.Background(),
-			components.KnownComponents(daemonVersion, allVersions))
+			allVersions,
+			components.IsInstalledFilter)
 		if err != nil {
 			return fmt.Errorf("could not list images: %v", err)
 		}
 
-		for _, img := range imgs {
-			fmt.Println(img)
+		cmps = append(cmps, components.Component{
+			Name:    "daemon",
+			Image:   "srcd/cli-daemon",
+			Version: daemonVersion,
+		})
+
+		for _, cmp := range cmps {
+			fmt.Println(cmp.ImageWithVersion())
 		}
 
 		return nil

--- a/cmd/srcd/cmd/init.go
+++ b/cmd/srcd/cmd/init.go
@@ -33,16 +33,9 @@ var initCmd = &cobra.Command{
 			logrus.Fatal("invalid number of arguments given, expecting 0 or 1")
 		}
 
-		ok, err := daemon.IsRunning()
+		err := daemon.Kill()
 		if err != nil {
-			logrus.Fatalf("can't get status of daemon: %s", err)
-		}
-
-		if ok {
-			logrus.Infof("daemon already running, killing it first")
-			if err := daemon.Kill(); err != nil {
-				logrus.Fatal(err)
-			}
+			logrus.Fatal(err)
 		}
 
 		var workdir string

--- a/cmd/srcd/daemon/daemon.go
+++ b/cmd/srcd/daemon/daemon.go
@@ -44,16 +44,20 @@ func SetCliVersion(v string) {
 }
 
 func DockerVersion() (string, error) { return docker.Version() }
-func IsRunning() (bool, error)       { return docker.IsRunning(daemonName) }
+func IsRunning() (bool, error)       { return docker.IsRunning(daemonName, "") }
 
 func Kill() error {
-	cmps, err := components.List(context.Background(), components.IsWorkingDirDependant)
+	cmps, err := components.List(
+		context.Background(),
+		true,
+		components.IsWorkingDirDependant,
+		components.IsRunningFilter)
 	if err != nil {
 		return err
 	}
 
 	for _, cmp := range cmps {
-		if err := docker.RemoveContainer(cmp); err != nil {
+		if err := cmp.Kill(); err != nil {
 			return err
 		}
 	}

--- a/components/components.go
+++ b/components/components.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/client"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/src-d/engine/docker"
@@ -26,6 +24,28 @@ type Component struct {
 
 func (c *Component) ImageWithVersion() string {
 	return fmt.Sprintf("%s:%s", c.Image, c.Version)
+}
+
+// Kill removes the Component container. If it is not running it returns nil
+func (c *Component) Kill() error {
+	err := docker.RemoveContainer(c.Name)
+	if err != nil && err != docker.ErrNotFound {
+		return err
+	}
+
+	return nil
+}
+
+// IsInstalled returns true if the Component image is installed with the
+// exact version
+func (c *Component) IsInstalled(ctx context.Context) (bool, error) {
+	return IsInstalled(ctx, c.ImageWithVersion())
+}
+
+// IsRunning returns true if the Component container is running using the
+// exact image version
+func (c *Component) IsRunning() (bool, error) {
+	return docker.IsRunning(c.Name, c.ImageWithVersion())
 }
 
 const (
@@ -61,43 +81,13 @@ var (
 		Gitbase,
 		Bblfshd, // does not depend on workdir but it does depend on user dir
 	}
-
-	componentsList = []Component{
-		Gitbase,
-		GitbaseWeb,
-		Bblfshd,
-		BblfshWeb,
-	}
 )
 
-func KnownComponents(daemonVersion string, allVersions bool) func(cmp string) bool {
-	componentsList := append(componentsList, Component{
-		Name:    "daemon",
-		Image:   "srcd/cli-daemon",
-		Version: daemonVersion,
-	})
+// FilterFunc is a filtering function for List.
+type FilterFunc func(Component) bool
 
-	return func(cmp string) bool {
-		for _, c := range componentsList {
-			var match bool
-			if !allVersions {
-				match = c.ImageWithVersion() == cmp
-			} else {
-				image, _ := splitImageID(cmp)
-				match = c.Image == image
-			}
-			if match {
-				return true
-			}
-		}
-		return false
-	}
-}
-
-type FilterFunc func(string) bool
-
-func filter(cmps []string, filters []FilterFunc) []string {
-	var result []string
+func filter(cmps []Component, filters []FilterFunc) []Component {
+	var result []Component
 	for _, cmp := range cmps {
 		var add = true
 		for _, f := range filters {
@@ -114,42 +104,88 @@ func filter(cmps []string, filters []FilterFunc) []string {
 	return result
 }
 
-func IsWorkingDirDependant(cmp string) bool {
+// IsWorkingDirDependant filters Components that depend on the working directory.
+var IsWorkingDirDependant FilterFunc = func(cmp Component) bool {
 	for _, c := range workDirDependants {
-		if c.Name == cmp {
+		if c.Image == cmp.Image {
 			return true
 		}
 	}
 	return false
 }
 
-func List(ctx context.Context, filters ...FilterFunc) ([]string, error) {
-	c, err := client.NewEnvClient()
+// IsInstalledFilter filters Components that have its image installed, with
+// the exact version
+var IsInstalledFilter FilterFunc = func(cmp Component) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	installed, err := docker.IsInstalled(ctx, cmp.Image, cmp.Version)
 	if err != nil {
-		return nil, err
+		//TODO log, or add err to FilterFunc
+		return false
 	}
 
-	imgs, err := c.ImageList(ctx, types.ImageListOptions{})
+	return installed
+}
+
+// IsRunningFilter filters Components that have a container running, using
+// its image with the exact version
+var IsRunningFilter FilterFunc = func(cmp Component) bool {
+	r, err := cmp.IsRunning()
 	if err != nil {
-		return nil, fmt.Errorf("could not list components: %v", err)
+		return false
 	}
 
-	var res []string
-	for _, img := range imgs {
-		if len(img.RepoTags) == 0 {
-			continue
+	return r
+}
+
+// List returns the list of known Components, which may or may not be installed.
+// If allVersions is true other Components with image versions different from
+// the current ones will be included.
+func List(ctx context.Context, allVersions bool, filters ...FilterFunc) ([]Component, error) {
+	componentsList := []Component{
+		Gitbase,
+		GitbaseWeb,
+		Bblfshd,
+		BblfshWeb,
+	}
+
+	if allVersions {
+		otherComponents := make([]Component, 0)
+
+		for _, cmp := range componentsList {
+			newCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+			defer cancel()
+
+			// Look for any other image version that might be installed
+			versions, err := docker.VersionsInstalled(newCtx, cmp.Image)
+			if err != nil {
+				return nil, err
+			}
+
+			for _, v := range versions {
+				if v == cmp.Version {
+					// Already added before
+					continue
+				}
+
+				otherComponents = append(otherComponents, Component{
+					Name:    cmp.Name,
+					Image:   cmp.Image,
+					Version: v,
+				})
+			}
 		}
 
-		if isSrcdComponent(img.RepoTags[0]) {
-			res = append(res, img.RepoTags[0])
-		}
+		componentsList = append(componentsList, otherComponents...)
 	}
 
 	if len(filters) > 0 {
-		return filter(res, filters), nil
+		return filter(componentsList, filters), nil
 	}
 
-	return res, nil
+	return componentsList, nil
 }
 
 var ErrNotSrcd = fmt.Errorf("not srcd component")
@@ -160,7 +196,7 @@ func Install(ctx context.Context, id string) error {
 		return ErrNotSrcd
 	}
 
-	image, version := splitImageID(id)
+	image, version := docker.SplitImageID(id)
 	return docker.Pull(ctx, image, version)
 }
 
@@ -169,7 +205,7 @@ func IsInstalled(ctx context.Context, id string) (bool, error) {
 		return false, ErrNotSrcd
 	}
 
-	image, version := splitImageID(id)
+	image, version := docker.SplitImageID(id)
 	return docker.IsInstalled(ctx, image, version)
 }
 
@@ -259,32 +295,22 @@ func removeVolumes() error {
 }
 
 func removeImages() error {
-	cmps, err := List(context.Background())
+	cmps, err := List(context.Background(), true, IsInstalledFilter)
 	if err != nil {
 		return errors.Wrap(err, "unable to list images")
 	}
 
 	for _, cmp := range cmps {
-		logrus.Infof("removing image %s", cmp)
+		logrus.Infof("removing image %s", cmp.ImageWithVersion())
 
 		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 		defer cancel()
-		if err := docker.RemoveImage(ctx, cmp); err != nil {
+		if err := docker.RemoveImage(ctx, cmp.ImageWithVersion()); err != nil {
 			return err
 		}
 	}
 
 	return nil
-}
-
-func splitImageID(id string) (image, version string) {
-	parts := strings.Split(id, ":")
-	image = parts[0]
-	version = "latest"
-	if len(parts) > 1 {
-		version = parts[1]
-	}
-	return
 }
 
 func stringInSlice(slice []string, str string) bool {
@@ -296,6 +322,7 @@ func stringInSlice(slice []string, str string) bool {
 	return false
 }
 
+// isSrcdComponent returns true if the Image repository (id) belongs to src-d
 func isSrcdComponent(id string) bool {
 	namespace := strings.Split(id, "/")[0]
 	return stringInSlice(srcdNamespaces, namespace)


### PR DESCRIPTION
Fix #60.

This replaces PR #134 with a different approach.

The code in  `Kill()` was there to stop the working directory dependencies, but somehow the image names and container names were mixed.
`Kill` needs container names for `RemoveContainer`, and `List` was returning image names. Besides that `KnownComponents` could not work because it was comparing image names to container names.

Now `components.List` returns `Components` instead of `strings`.

I also changed `init` to delete the daemon dependencies even if the daemon itself is not running.

Since `List` now returns only managed `Components` instead of all images that pass `isSrcdComponent` (image org `srcd` or `bblfsh`), this PR also fixes  #137.