### PR TITLE
Format components list output as table

### DIFF
--- a/components/components.go
+++ b/components/components.go
@@ -3,6 +3,7 @@ package components
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -220,6 +221,10 @@ func List(ctx context.Context, allVersions bool, filters ...FilterFunc) ([]Compo
 
 		componentsList = append(componentsList, otherComponents...)
 	}
+
+	sort.Slice(componentsList, func(i, j int) bool {
+		return componentsList[i].ImageWithVersion() < componentsList[j].ImageWithVersion()
+	})
 
 	if len(filters) > 0 {
 		return filter(componentsList, filters)


### PR DESCRIPTION
Related to #118.

This PR adds extra info to `components list`.
Before:
```
$ srcd components list 
srcd/cli-daemon:latest
srcd/gitbase:v0.17.1
bblfsh/bblfshd:v2.9.2-drivers

$ srcd components list -a
srcd/cli-daemon:latest
srcd/gitbase:v0.17.1
bblfsh/bblfshd:v2.9.2-drivers
srcd/cli-daemon:v0.2.0
srcd/gitbase-web:latest
bblfsh/bblfshd:latest
bblfsh/bblfshd:v2.9.1
bblfsh/bblfshd:v2.9.0-drivers
```

After:
```
$ srcd components list 
IMAGE                            INSTALLED    RUNNING    CONTAINER NAME
bblfsh/bblfshd:v2.9.2-drivers    yes          no         srcd-cli-bblfshd
bblfsh/web:v0.7.0                no           no         srcd-cli-bblfsh-web
srcd/cli-daemon:latest           yes          yes        srcd-cli-daemon
srcd/gitbase-web:v0.3.0          no           no         srcd-cli-gitbase-web
srcd/gitbase:v0.17.1             yes          no         srcd-cli-gitbase

$ srcd components list -a
IMAGE                            INSTALLED    RUNNING    CONTAINER NAME
bblfsh/bblfshd:latest            yes          no         srcd-cli-bblfshd
bblfsh/bblfshd:v2.9.0-drivers    yes          no         srcd-cli-bblfshd
bblfsh/bblfshd:v2.9.1            yes          no         srcd-cli-bblfshd
bblfsh/bblfshd:v2.9.2-drivers    yes          no         srcd-cli-bblfshd
bblfsh/web:v0.7.0                no           no         srcd-cli-bblfsh-web
srcd/cli-daemon:latest           yes          yes        srcd-cli-daemon
srcd/cli-daemon:v0.2.0           yes          no         srcd-cli-daemon
srcd/gitbase-web:latest          yes          no         srcd-cli-gitbase-web
srcd/gitbase-web:v0.3.0          no           no         srcd-cli-gitbase-web
srcd/gitbase:v0.17.1             yes          no         srcd-cli-gitbase

```