### PR TITLE
Use Components for srcd components install

### DIFF
--- a/cmd/srcd/daemon/daemon.go
+++ b/cmd/srcd/daemon/daemon.go
@@ -47,7 +47,7 @@ func Kill() error {
 		context.Background(),
 		true,
 		components.IsWorkingDirDependant,
-		components.IsRunningFilter)
+		components.IsRunning)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Using `Component`s for `srcd components install` means that we allow to install only the exact images (and versions) engine manages, instead of any image with the `srcd/` or `bblfsh/` prefix as we do in master.

With this PR we also get a nicer error when the component to install is not found:
```
$ srcd install srcd/lookout
Error: srcd/lookout is not valid. Component must be one of [srcd/cli-daemon, srcd/gitbase, srcd/gitbase-web, bblfsh/bblfshd, bblfsh/web]
```