### PR TITLE
docs: Remove reference to "srcd parse native".

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -7,7 +7,6 @@ they've been implemented.
 - [srcd version](#srcd-version)
 - [srcd parse](#srcd-parse)
     - [srcd parse uast](#srcd-parse-uast)
-    - [srcd parse native](#srcd-parse-native)
     - [srcd parse lang](#srcd-parse-lang)
     - [srcd parse drivers](#srcd-parse-drivers)
         - [srcd parse drivers list](#srcd-parse-drivers-list)


### PR DESCRIPTION
This command is not implemented; instead (it appears) the intended use is to
pass "-m native" to the "srcd parse uast" subcommand.

Signed-off-by: M. J. Fromberger <michael.j.fromberger@gmail.com>