### PR TITLE
Use tag for daemon version

### DIFF
--- a/cmd/srcd-server/Dockerfile
+++ b/cmd/srcd-server/Dockerfile
@@ -9,7 +9,7 @@ ENV ROOTPATH=github.com/src-d/engine
 
 ADD . /go/src/${ROOTPATH}
 WORKDIR /go/src/${ROOTPATH}
-RUN HEAD=$(git rev-parse HEAD) && go install -ldflags "-X main.version=${HEAD}" "${ROOTPATH}/cmd/srcd-server"
+RUN TAG=$(git describe --tags) && go install -ldflags "-X main.version=${TAG}" "${ROOTPATH}/cmd/srcd-server"
 
 FROM alpine
 RUN apk update && \


### PR DESCRIPTION
With this change the daemon version is set to the tag name, instead of the HEAD sha1.

Before:
```
$ ./srcd version
srcd cli version: v0.4.0
docker version: 1.39
srcd daemon version: 3b1b6726ccc717a5a21833ab00df717cd6fd61d8
```
After:
```
$ ./srcd version
srcd cli version: v0.4.0
docker version: 1.39
srcd daemon version: v0.4.0
```