### PR TITLE
Bblfshd v2.11.0

### DIFF
--- a/cmd/srcd-server/engine/components.go
+++ b/cmd/srcd-server/engine/components.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/src-d/engine/api"
-	"github.com/src-d/engine/components"
 	"github.com/src-d/engine/docker"
 )
 
@@ -111,8 +110,6 @@ func (s *Server) bblfshComponent() Component {
 	return Component{
 		Name: bblfshd.Name,
 		Start: createBbblfshd(
-			s.installStableDrivers,
-			docker.WithVolume(components.BblfshVolume, bblfshMountPath),
 			docker.WithPort(bblfshParsePort, bblfshParsePort),
 		),
 	}

--- a/cmd/srcd-server/engine/parse.go
+++ b/cmd/srcd-server/engine/parse.go
@@ -19,7 +19,6 @@ import (
 )
 
 const (
-	bblfshMountPath   = "/var/lib/bblfshd"
 	bblfshParsePort   = 9432
 	bblfshControlPort = 9433
 )
@@ -130,13 +129,9 @@ func (s *Server) parse(ctx context.Context, req *api.ParseRequest, log logf) (*a
 	return resp, nil
 }
 
-func createBbblfshd(setupFunc docker.StartFunc, opts ...docker.ConfigOption) docker.StartFunc {
+func createBbblfshd(opts ...docker.ConfigOption) docker.StartFunc {
 	return func(ctx context.Context) error {
 		if err := docker.EnsureInstalled(bblfshd.Image, bblfshd.Version); err != nil {
-			return err
-		}
-
-		if err := docker.CreateVolume(ctx, components.BblfshVolume); err != nil {
 			return err
 		}
 
@@ -153,10 +148,6 @@ func createBbblfshd(setupFunc docker.StartFunc, opts ...docker.ConfigOption) doc
 		host := &container.HostConfig{Privileged: true}
 		docker.ApplyOptions(config, host, opts...)
 
-		if err := docker.Start(ctx, config, host, bblfshd.Name); err != nil {
-			return err
-		}
-
-		return setupFunc(ctx)
+		return docker.Start(ctx, config, host, bblfshd.Name)
 	}
 }

--- a/cmd/srcd-server/engine/parse.go
+++ b/cmd/srcd-server/engine/parse.go
@@ -67,18 +67,6 @@ func (s *Server) parse(ctx context.Context, req *api.ParseRequest, log logf) (*a
 		return nil, err
 	}
 
-	dclient, err := s.bblfshDriverClient(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	err = s.installDriver(ctx, dclient, lang, "latest", false)
-	if err == ErrDriverAlreadyInstalled {
-		log("driver was already installed")
-	} else if err != nil {
-		return nil, err
-	}
-
 	addr := fmt.Sprintf("%s:%d", bblfshd.Name, bblfshParsePort)
 	log("connecting to bblfsh parsing on %s", addr)
 	client, err := bblfsh.NewClient(addr)

--- a/components/components.go
+++ b/components/components.go
@@ -102,7 +102,7 @@ var (
 	Bblfshd = Component{
 		Name:    "srcd-cli-bblfshd",
 		Image:   "bblfsh/bblfshd",
-		Version: "v2.10.0-drivers",
+		Version: "v2.11.0-drivers",
 	}
 
 	BblfshWeb = Component{

--- a/components/components.go
+++ b/components/components.go
@@ -82,10 +82,6 @@ func daemonRetrieveVersion(daemon *Component) (string, bool, error) {
 	return docker.GetCompatibleTag(daemon.Image, cliVersion)
 }
 
-const (
-	BblfshVolume = "srcd-cli-bblfsh-storage"
-)
-
 var (
 	Gitbase = Component{
 		Name:    "srcd-cli-gitbase",


### PR DESCRIPTION
Fix #159, Fix #160.

This PR updates bblfsd to v2.11.0.

I also included here the removal of the drivers installation. The reason why it was not removed before is that the `cpp` driver was not included in the `2.10.0` image (see [context here](https://github.com/src-d/engine/pull/135)). In 2.11.0 it is included, so we can skip the driver installation step.

I also removed the bblfsd volume, since it was used to store the installed drivers only.

I did not remove any of the code to install drivers because we might use it in the future. For example if we need to install specific drivers versions.