### PR TITLE
Fix error returned for container creation failures

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -367,8 +367,8 @@ func forceContainerCreate(
 	}
 
 	// in case of error res doesn't contain ID of the container
-	info, err := Info(name)
-	if err != nil {
+	info, errInfo := Info(name)
+	if errInfo != nil {
 		return res, err
 	}
 


### PR DESCRIPTION
Part of #164.

The code does a container creation. If it fails, it checks if a container with that name already exists, deletes it, and retries.
The problem is that in case no other container exists, we were returning the `Info` error message, instead of the `ContainerCreate` error.

So for `srcd init /tmp/nope` & `srcd web sql` you get this message in master:
```
FATA[0010] could not start gitbase web client at port 8080: rpc error: code = Unknown desc = could not create srcd-cli-gitbase: could not create container srcd-cli-gitbase: container not found 
```

And with this PR you get the real reason:
```
FATA[0009] could not start gitbase web client at port 8080: rpc error: code = Unknown desc = could not create srcd-cli-gitbase: could not create container srcd-cli-gitbase: Error response from daemon: invalid mount config for type "bind": bind source path does not exist: /tmp/nope
```

This is not #164 root cause, but it will probably be something easy to fix if we return the proper error.