### PR TITLE
Check workdir is valid before starting containers

### DIFF
--- a/cmd/srcd/cmd/init.go
+++ b/cmd/srcd/cmd/init.go
@@ -56,6 +56,11 @@ var initCmd = &cobra.Command{
 			}
 		}
 
+		info, err := os.Stat(workdir)
+		if err != nil || !info.IsDir() {
+			logrus.Fatalf("path %q is not a valid working directory", workdir)
+		}
+
 		logrus.Infof("starting daemon with working directory: %s", workdir)
 
 		if err := daemon.Start(workdir); err != nil {


### PR DESCRIPTION
Working on #166 I've realized that it doesn't make sense to try to create containers with an invalid workdir, when beforehand is so simple.