### PR TITLE
Just some improvements on init.go

### DIFF
--- a/cmd/srcd/cmd/init.go
+++ b/cmd/srcd/cmd/init.go
@@ -28,11 +28,8 @@ import (
 var initCmd = &cobra.Command{
 	Use:   "init",
 	Short: "Starts the daemon or restarts it if already running.",
+	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		if len(args) > 1 {
-			logrus.Fatal("invalid number of arguments given, expecting 0 or 1")
-		}
-
 		err := daemon.Kill()
 		if err != nil {
 			logrus.Fatal(err)

--- a/cmd/srcd/cmd/init.go
+++ b/cmd/srcd/cmd/init.go
@@ -30,12 +30,9 @@ var initCmd = &cobra.Command{
 	Short: "Starts the daemon or restarts it if already running.",
 	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		err := daemon.Kill()
-		if err != nil {
-			logrus.Fatal(err)
-		}
-
+		var err error
 		var workdir string
+
 		if len(args) > 0 {
 			workdir = args[0]
 		}
@@ -56,6 +53,11 @@ var initCmd = &cobra.Command{
 		info, err := os.Stat(workdir)
 		if err != nil || !info.IsDir() {
 			logrus.Fatalf("path %q is not a valid working directory", workdir)
+		}
+
+		err = daemon.Kill()
+		if err != nil {
+			logrus.Fatal(err)
 		}
 
 		logrus.Infof("starting daemon with working directory: %s", workdir)

--- a/cmd/srcd/cmd/init.go
+++ b/cmd/srcd/cmd/init.go
@@ -40,14 +40,11 @@ var initCmd = &cobra.Command{
 		workdir = strings.TrimSpace(workdir)
 		if workdir == "" {
 			workdir, err = os.Getwd()
-			if err != nil {
-				logrus.Fatal(err)
-			}
 		} else {
 			workdir, err = filepath.Abs(workdir)
-			if err != nil {
-				logrus.Fatal(err)
-			}
+		}
+		if err != nil {
+			logrus.Fatal(err)
 		}
 
 		info, err := os.Stat(workdir)


### PR DESCRIPTION
By using the standard `Args` key of Cobra `Command`, the error message in case of a number of arguments > 1 changes from:

```
✘  se7entyse7en in ~/Projects/src-d/engine/cmd/srcd (init-cmd-clean)  $ srcd init foo bar                                                                                        [12/26/18 | 13:06:40.051]
FATA[0000] invalid number of arguments given, expecting 0 or 1
```

to:

```
✔  se7entyse7en in ~/Projects/src-d/engine/cmd/srcd (init-cmd-clean)  $ go run main.go init foo bar                                                                              [12/26/18 | 13:06:17.418]
Error: accepts at most 1 arg(s), received 2
Usage:
  srcd init [flags]

Flags:
  -h, --help   help for init

Global Flags:
      --config string   config file (default is $HOME/.srcd.yaml)
  -v, --verbose         if true, log all of the things

accepts at most 1 arg(s), received 2
exit status 1
```