### PR TITLE
Sql install deps

### DIFF
--- a/cmd/srcd/cmd/root.go
+++ b/cmd/srcd/cmd/root.go
@@ -103,9 +103,14 @@ func logAfterTimeout(header string) chan struct{} {
 			logrus.Info(header)
 			scanner := bufio.NewScanner(logs)
 			for scanner.Scan() {
-				match := logMsgRegex.FindStringSubmatch(scanner.Text())
-				if len(match) == 2 {
-					logrus.Info(match[1])
+				select {
+				case <-started:
+					return
+				default:
+					match := logMsgRegex.FindStringSubmatch(scanner.Text())
+					if len(match) == 2 {
+						logrus.Info(match[1])
+					}
 				}
 			}
 			if err := scanner.Err(); err != nil && err != context.Canceled {

--- a/cmd/srcd/cmd/sql.go
+++ b/cmd/srcd/cmd/sql.go
@@ -52,7 +52,9 @@ var sqlCmd = &cobra.Command{
 			logrus.Fatalf("could not get daemon client: %v", err)
 		}
 
-		started := logAfterTimeout("this is taking a while, if this is the first time you launch sql client, it might take a few more minutes while we install all the required images")
+		started := logAfterTimeout("this is taking a while, " +
+			"if this is the first time you launch sql client, " +
+			"it might take a few more minutes while we install all the required images")
 
 		// Might have to pull some images
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)

--- a/cmd/srcd/cmd/sql.go
+++ b/cmd/srcd/cmd/sql.go
@@ -26,9 +26,11 @@ import (
 
 	"github.com/chzyer/readline"
 	"github.com/olekukonko/tablewriter"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/src-d/engine/api"
 	"github.com/src-d/engine/cmd/srcd/daemon"
+	"github.com/src-d/engine/components"
 )
 
 // sqlCmd represents the sql command
@@ -43,6 +45,24 @@ var sqlCmd = &cobra.Command{
 		var query string
 		if len(args) == 1 {
 			query = args[0]
+		}
+
+		c, err := daemon.Client()
+		if err != nil {
+			logrus.Fatalf("could not get daemon client: %v", err)
+		}
+
+		started := logAfterTimeout("this is taking a while, if this is the first time you launch sql client, it might take a few more minutes while we install all the required images")
+
+		// Might have to pull some images
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+		_, err = c.StartComponent(ctx, &api.StartComponentRequest{
+			Name: components.Gitbase.Name,
+		})
+		close(started)
+		cancel()
+		if err != nil {
+			logrus.Fatalf("could not start gitbase: %v", err)
 		}
 
 		if strings.TrimSpace(query) == "" {


### PR DESCRIPTION
Fix: #152

1st commit implements installation before starting repl.
2nd commit fixes a bug that we still read logs after started channel is closed.

Example output:
```
$ go run cmd/srcd/main.go sql
INFO[0005] this is taking a while, if this is the first time you launch sql client, it might take a few more minutes while we install all the required images
INFO[0005] installing \"bblfsh/bblfshd:v2.11.0-drivers\"
INFO[0102] installed \"bblfsh/bblfshd:v2.11.0-drivers\"
INFO[0102] starting bblfshd daemon
gitbase> select * from repositories;
+---------------+
| REPOSITORY ID |
+---------------+
| repos         |
+---------------+
```