### PR TITLE
Increase start containers timeout to 60s

### DIFF
--- a/cmd/srcd-server/engine/components.go
+++ b/cmd/srcd-server/engine/components.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	startComponentTimeout = 30 * time.Second
+	startComponentTimeout = 60 * time.Second
 )
 
 // Component to be run.


### PR DESCRIPTION
Fix #197, #204.

After reading the descriptions in #197 & #204 the only workaround I can think of is increasing the timeout. 30 seconds sounds like it should be enough to create a container, but maybe in mac OS it is different since it does nested virtualization.

While increasing the timeout may not address the problem, maybe it allows enough time for the docker api to return a proper error with more information.