### PR TITLE
Update bblfshd to v2.11.6

### DIFF
--- a/components/components.go
+++ b/components/components.go
@@ -98,7 +98,7 @@ var (
 	Bblfshd = Component{
 		Name:    "srcd-cli-bblfshd",
 		Image:   "bblfsh/bblfshd",
-		Version: "v2.11.0-drivers",
+		Version: "v2.11.6-drivers",
 	}
 
 	BblfshWeb = Component{


### PR DESCRIPTION
There aren't release notes for the `-drivers` image, but this one includes the new `csharp` driver.