### PR TITLE
Limit travis builds to master and release tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
+branches:
+  only:
+    - master
+    - /^v\d+\.\d+(\.\d+)?(-\S*)?$/
+
 dist: xenial
 sudo: required
 


### PR DESCRIPTION
Part of #221.

Dependabot will create PRs from branches in this repo, and those create too many duplicated travis builds for both the PR and the branch. This PR limits the builds to master and release tags.