### PR TITLE
fix panic on stopping web command

### DIFF
--- a/cmd/srcd/cmd/web.go
+++ b/cmd/srcd/cmd/web.go
@@ -78,7 +78,6 @@ func startWebComponent(name, desc string) func(cmd *cobra.Command, args []string
 		signal.Notify(ch, os.Interrupt, os.Kill)
 
 		<-ch
-		close(ch)
 
 		ctx, cancel = context.WithTimeout(context.Background(), 10*time.Minute)
 		defer cancel()
@@ -88,6 +87,8 @@ func startWebComponent(name, desc string) func(cmd *cobra.Command, args []string
 			cancel()
 			logrus.Fatalf("could not stop %s: %v", desc, err)
 		}
+
+		close(ch)
 	}
 }
 


### PR DESCRIPTION
fix: #255

Closing signal channel should be the last thing to do before exiting.
Another solution would be not to close it at all because we exit anyway.

Signed-off-by: Maxim Sukharev <max@smacker.ru>