### PR TITLE
Use normal build for integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,3 @@ main
 # CI
 .ci/
 build/
-build-integration/

--- a/Makefile
+++ b/Makefile
@@ -15,26 +15,9 @@ $(MAKEFILE):
 
 -include $(MAKEFILE)
 
-LD_FLAGS_IMAGE_PREFIX = -X github.com/src-d/engine/components.imageNamePrefix=integration-testing-scrd-cli-
-LD_FLAGS_INTEGRATION = -X main.version=integration-testing -X main.build=$(BUILD) -X main.commit=$(COMMIT) $(LD_FLAGS_IMAGE_PREFIX)
+GOTEST_INTEGRATION = $(GOTEST) -parallel 1 -count 1 -tags=integration -ldflags "$(LD_FLAGS)"
 
-GOTEST_INTEGRATION = $(GOTEST) -parallel 1 -count 1 -tags=integration -ldflags "$(LD_FLAGS_INTEGRATION)"
-
-INTEGRATION_TEST_BUILD_PATH = "build-integration"
-INTEGRATION_TEST_BIN_PATH = $(INTEGRATION_TEST_BUILD_PATH)/bin
-
-GOBUILD_INTEGRATION = $(GOCMD) build -ldflags "$(LD_FLAGS_INTEGRATION)"
-
-clean-integration:
-	rm -rf $(INTEGRATION_TEST_BUILD_PATH)
-build-integration: BUILD_PATH=$(INTEGRATION_TEST_BUILD_PATH)
-build-integration: BIN_PATH=$(INTEGRATION_TEST_BIN_PATH)
-build-integration: GOBUILD=$(GOBUILD_INTEGRATION)
-build-integration: build
-
-build-integration-daemon:
-	docker build --build-arg go_ldflags="$(LD_FLAGS_IMAGE_PREFIX)" -t srcd/cli-daemon:integration-testing -f cmd/srcd-server/Dockerfile .
-
-test-integration-no-daemon: clean-integration build-integration
+test-integration-no-build:
 	$(GOTEST_INTEGRATION) github.com/src-d/engine/cmd/srcd/cmd/
-test-integration: build-integration-daemon test-integration-no-daemon
+
+test-integration: clean build docker-build test-integration-no-build

--- a/cmd/srcd-server/Dockerfile
+++ b/cmd/srcd-server/Dockerfile
@@ -3,15 +3,13 @@
 FROM golang:1.10 as builder
 
 ENV ROOTPATH=github.com/src-d/engine
-ARG go_ldflags
-ENV EXTRA_LDFLAGS=${go_ldflags}
 
 # update gRPC api?
 # RUN go get github.com/golang/protobuf/protoc-gen-go
 
 ADD . /go/src/${ROOTPATH}
 WORKDIR /go/src/${ROOTPATH}
-RUN TAG=$(git describe --tags) && go install -ldflags "-X main.version=${TAG} ${EXTRA_LDFLAGS}" "${ROOTPATH}/cmd/srcd-server"
+RUN TAG=$(git describe --tags) && go install -ldflags "-X main.version=${TAG}" "${ROOTPATH}/cmd/srcd-server"
 
 FROM alpine
 RUN apk update && \

--- a/cmd/test-utils/common.go
+++ b/cmd/test-utils/common.go
@@ -16,7 +16,8 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-var srcdBin = fmt.Sprintf("../../../build-integration/engine_%s_%s/srcd", runtime.GOOS, runtime.GOARCH)
+// TODO (carlosms) this could be build/bin, workaround for https://github.com/src-d/ci/issues/97
+var srcdBin = fmt.Sprintf("../../../build/engine_%s_%s/srcd", runtime.GOOS, runtime.GOARCH)
 var configFile = "../../../integration-testing-config.yaml"
 
 type IntegrationSuite struct {

--- a/components/components.go
+++ b/components/components.go
@@ -15,9 +15,6 @@ import (
 // cli version set by src-d command
 var cliVersion = ""
 
-// prefix to use for the docker images
-var imageNamePrefix = "srcd-cli-"
-
 // SetCliVersion sets cli version
 func SetCliVersion(v string) {
 	cliVersion = v
@@ -85,37 +82,33 @@ func daemonRetrieveVersion(daemon *Component) (string, bool, error) {
 	return docker.GetCompatibleTag(daemon.Image, cliVersion)
 }
 
-func componentName(suffix string) string {
-	return fmt.Sprintf("%s%s", imageNamePrefix, suffix)
-}
-
 var (
 	Gitbase = Component{
-		Name:    componentName("gitbase"),
+		Name:    "srcd-cli-gitbase",
 		Image:   "srcd/gitbase",
 		Version: "v0.19.0",
 	}
 
 	GitbaseWeb = Component{
-		Name:    componentName("gitbase-web"),
+		Name:    "srcd-cli-gitbase-web",
 		Image:   "srcd/gitbase-web",
 		Version: "v0.6.2",
 	}
 
 	Bblfshd = Component{
-		Name:    componentName("bblfshd"),
+		Name:    "srcd-cli-bblfshd",
 		Image:   "bblfsh/bblfshd",
 		Version: "v2.11.8-drivers",
 	}
 
 	BblfshWeb = Component{
-		Name:    componentName("bblfsh-web"),
+		Name:    "srcd-cli-bblfsh-web",
 		Image:   "bblfsh/web",
 		Version: "v0.9.0",
 	}
 
 	Daemon = Component{
-		Name:  componentName("daemon"),
+		Name:  "srcd-cli-daemon",
 		Image: "srcd/cli-daemon",
 		// Version
 		retrieveVersionFunc: daemonRetrieveVersion,
@@ -340,5 +333,5 @@ func removeImages() error {
 }
 
 func isFromEngine(name string) bool {
-	return strings.HasPrefix(name, imageNamePrefix)
+	return strings.HasPrefix(name, "srcd-cli-")
 }

--- a/docker/dockerhub.go
+++ b/docker/dockerhub.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/blang/semver"
 	"github.com/pkg/errors"
@@ -13,12 +14,8 @@ import (
 // GetCompatibleTag returns the semver tag of an image compatible with the
 // currentVersion, and true if there are any newer versions with breaking changes
 func GetCompatibleTag(image, currentVersion string) (string, bool, error) {
-	if currentVersion == "" || currentVersion == "dev" {
+	if currentVersion == "" || strings.HasPrefix(currentVersion, "dev") {
 		return "latest", false, nil
-	}
-
-	if currentVersion == "integration-testing" {
-		return currentVersion, false, nil
 	}
 
 	cliV, err := semver.ParseTolerant(currentVersion)

--- a/docker/dockerhub.go
+++ b/docker/dockerhub.go
@@ -14,8 +14,14 @@ import (
 // GetCompatibleTag returns the semver tag of an image compatible with the
 // currentVersion, and true if there are any newer versions with breaking changes
 func GetCompatibleTag(image, currentVersion string) (string, bool, error) {
-	if currentVersion == "" || strings.HasPrefix(currentVersion, "dev") {
+	// For go run
+	if currentVersion == "" || currentVersion == "dev" {
 		return "latest", false, nil
+	}
+
+	// For local builds without a release tag, e.g. dev-5045ba7-dirty
+	if strings.HasPrefix(currentVersion, "dev") {
+		return currentVersion, false, nil
 	}
 
 	cliV, err := semver.ParseTolerant(currentVersion)


### PR DESCRIPTION
Part of #232.

This reverts some of the changes made in #302 related to the build flags, and having a different special build for `make test-integration`.

With this PR these two things are equivalent:
```
make test-integration
```
```
make build
make docker-build
make test-integration-no-build
```

The advantage is that we are testing the normal build process. Which means that you can for example download the binary for v0.11.0-rc.3, put it in `build/engine_GOOS_GOARCH/srcd`, and run `make test-integration-no-build` (if you do you will see that the current test detects the bug #252).