### PR TITLE
show public ports of components in components list

### DIFF
--- a/cmd/srcd/cmd/components.go
+++ b/cmd/srcd/cmd/components.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/docker/docker/api/types"
 	"github.com/spf13/cobra"
 	"github.com/src-d/engine/components"
 )
@@ -47,13 +48,14 @@ var componentsListCmd = &cobra.Command{
 		}
 
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 4, ' ', 0)
-		fmt.Fprintf(w, "IMAGE\tINSTALLED\tRUNNING\tCONTAINER NAME\n")
+		fmt.Fprintf(w, "IMAGE\tINSTALLED\tRUNNING\tPORT\tCONTAINER NAME\n")
 
 		for _, cmp := range cmps {
-			fmt.Fprintf(w, "%s\t%s\t%v\t%v\n",
+			fmt.Fprintf(w, "%s\t%s\t%v\t%v\t%v\n",
 				cmp.ImageWithVersion(),
 				boolFmt(cmp.IsInstalled()),
 				boolFmt(cmp.IsRunning()),
+				publicPortsFmt(cmp.GetPorts()),
 				cmp.Name,
 			)
 		}
@@ -73,6 +75,21 @@ func boolFmt(b bool, err error) string {
 	}
 
 	return "no"
+}
+
+func publicPortsFmt(ps []types.Port, err error) string {
+	if err != nil {
+		return "?"
+	}
+
+	var publicPorts []string
+	for _, p := range ps {
+		if p.PublicPort != 0 {
+			publicPorts = append(publicPorts, fmt.Sprintf("%d", p.PublicPort))
+		}
+	}
+
+	return strings.Join(publicPorts, ",")
 }
 
 // componentsCmd represents the components install command

--- a/cmd/srcd/cmd/components.go
+++ b/cmd/srcd/cmd/components.go
@@ -22,9 +22,9 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	"github.com/docker/docker/api/types"
 	"github.com/spf13/cobra"
 	"github.com/src-d/engine/components"
+	"github.com/src-d/engine/docker"
 )
 
 // componentsCmd represents the components command
@@ -77,7 +77,7 @@ func boolFmt(b bool, err error) string {
 	return "no"
 }
 
-func publicPortsFmt(ps []types.Port, err error) string {
+func publicPortsFmt(ps []docker.Port, err error) string {
 	if err != nil {
 		return "?"
 	}

--- a/cmd/srcd/cmd/components_test.go
+++ b/cmd/srcd/cmd/components_test.go
@@ -47,12 +47,12 @@ func (s *ComponentsTestSuite) TestListStopped() {
 	require.NoError(err, out.String())
 
 	expected := regexp.MustCompile(
-		`^IMAGE +INSTALLED +RUNNING +CONTAINER NAME
-bblfsh/bblfshd:\S+ +(yes|no) +no +srcd-cli-bblfshd
-bblfsh/web:\S+ +(yes|no) +no +srcd-cli-bblfsh-web
-srcd/cli-daemon:\S+ +(yes|no) +no +srcd-cli-daemon
-srcd/gitbase-web:\S+ +(yes|no) +no +srcd-cli-gitbase-web
-srcd/gitbase:\S+ +(yes|no) +no +srcd-cli-gitbase
+		`^IMAGE +INSTALLED +RUNNING +PORT +CONTAINER NAME
+bblfsh/bblfshd:\S+ +(yes|no) +no +(\d+)? +srcd-cli-bblfshd
+bblfsh/web:\S+ +(yes|no) +no +(\d+)? +srcd-cli-bblfsh-web
+srcd/cli-daemon:\S+ +(yes|no) +no +(\d+)? +srcd-cli-daemon
+srcd/gitbase-web:\S+ +(yes|no) +no +(\d+)? +srcd-cli-gitbase-web
+srcd/gitbase:\S+ +(yes|no) +no +(\d+)? +srcd-cli-gitbase
 $`)
 
 	s.Regexp(expected, out.String())
@@ -67,7 +67,7 @@ func (s *ComponentsTestSuite) TestListInit() {
 	out, err = s.RunCommand(context.TODO(), "components", "list")
 	require.NoError(err, out.String())
 
-	expected := regexp.MustCompile(`srcd/cli-daemon:\S+ +yes +yes +srcd-cli-daemon`)
+	expected := regexp.MustCompile(`srcd/cli-daemon:\S+ +yes +yes +4252 +srcd-cli-daemon`)
 	s.Regexp(expected, out.String())
 }
 

--- a/components/components.go
+++ b/components/components.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/docker/docker/api/types"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/src-d/engine/docker"
@@ -59,6 +60,19 @@ func (c *Component) Install() error {
 // exact image version
 func (c *Component) IsRunning() (bool, error) {
 	return docker.IsRunning(c.Name, c.ImageWithVersion())
+}
+
+// GetPorts returns component ports of the component if there is any
+func (c *Component) GetPorts() ([]types.Port, error) {
+	info, err := docker.Info(c.Name)
+	if err == docker.ErrNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return info.Ports, nil
 }
 
 // RetrieveVersion updates the Version field with a compatible tag for the

--- a/components/components.go
+++ b/components/components.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/docker/docker/api/types"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/src-d/engine/docker"
@@ -63,7 +62,7 @@ func (c *Component) IsRunning() (bool, error) {
 }
 
 // GetPorts returns component ports of the component if there is any
-func (c *Component) GetPorts() ([]types.Port, error) {
+func (c *Component) GetPorts() ([]docker.Port, error) {
 	info, err := docker.Info(c.Name)
 	if err == docker.ErrNotFound {
 		return nil, nil

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -21,6 +21,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+type Port = types.Port
+
 func Version() (string, error) {
 	c, err := client.NewEnvClient()
 	if err != nil {


### PR DESCRIPTION
fix: #300

Integration test checks that the correct port is displayed in `TestListInit`.
Please let me know if you think I should remove it from there and add another test case especially for the ports.