### PR TITLE
Group containers private ports const definitions

### DIFF
--- a/api/config.go
+++ b/api/config.go
@@ -1,5 +1,9 @@
 package api
 
+import (
+	"github.com/src-d/engine/components"
+)
+
 // Config holds the config.yml file values
 type Config struct {
 	Components struct {
@@ -33,7 +37,7 @@ type Config struct {
 // SetDefaults fills the default values for any fields that are not set
 func (c *Config) SetDefaults() {
 	if c.Components.Bblfshd.Port == 0 {
-		c.Components.Bblfshd.Port = 9432
+		c.Components.Bblfshd.Port = components.BblfshParsePort
 	}
 
 	if c.Components.BblfshWeb.Port == 0 {
@@ -45,10 +49,10 @@ func (c *Config) SetDefaults() {
 	}
 
 	if c.Components.Gitbase.Port == 0 {
-		c.Components.Gitbase.Port = 3306
+		c.Components.Gitbase.Port = components.GitbasePort
 	}
 
 	if c.Components.Daemon.Port == 0 {
-		c.Components.Daemon.Port = 4242
+		c.Components.Daemon.Port = components.DaemonPort
 	}
 }

--- a/cmd/srcd-server/engine/components.go
+++ b/cmd/srcd-server/engine/components.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/src-d/engine/api"
+	"github.com/src-d/engine/components"
 	"github.com/src-d/engine/docker"
 )
 
@@ -89,7 +90,7 @@ func (s *Server) startComponentAtPort(
 
 		return publicPort, Run(ctx, Component{
 			Name:         gitbaseWeb.Name,
-			Start:        createGitbaseWeb(docker.WithPort(publicPort, gitbaseWebPrivatePort)),
+			Start:        createGitbaseWeb(docker.WithPort(publicPort, components.GitbaseWebPort)),
 			Dependencies: []Component{*gbComp},
 		})
 	case bblfshWeb.Name:
@@ -100,7 +101,7 @@ func (s *Server) startComponentAtPort(
 
 		return publicPort, Run(ctx, Component{
 			Name:         bblfshWeb.Name,
-			Start:        createBblfshWeb(docker.WithPort(publicPort, bblfshWebPrivatePort)),
+			Start:        createBblfshWeb(docker.WithPort(publicPort, components.BblfshWebPort)),
 			Dependencies: []Component{*bbfComp},
 		})
 	case bblfshd.Name:
@@ -130,16 +131,16 @@ func (s *Server) getPublicPort(name string, requestedPort int) int {
 	switch name {
 	case gitbaseWeb.Name:
 		defaultPort = s.config.Components.GitbaseWeb.Port
-		privatePort = gitbaseWebPrivatePort
+		privatePort = components.GitbaseWebPort
 	case bblfshWeb.Name:
 		defaultPort = s.config.Components.BblfshWeb.Port
-		privatePort = bblfshWebPrivatePort
+		privatePort = components.BblfshWebPort
 	case bblfshd.Name:
 		defaultPort = s.config.Components.Bblfshd.Port
-		privatePort = bblfshParsePort
+		privatePort = components.BblfshParsePort
 	case gitbase.Name:
 		defaultPort = s.config.Components.Gitbase.Port
-		privatePort = gitbasePort
+		privatePort = components.GitbasePort
 	}
 
 	switch requestedPort {
@@ -177,7 +178,7 @@ func (s *Server) gitbaseComponent(port int) (*Component, error) {
 		Start: createGitbase(
 			docker.WithSharedDirectory(workdirHostPath, gitbaseMountPath),
 			docker.WithSharedDirectory(indexDirHostPath, gitbaseIndexMountPath),
-			docker.WithPort(port, gitbasePort),
+			docker.WithPort(port, components.GitbasePort),
 		),
 		Dependencies: []Component{*bblfshComponent},
 	}, nil
@@ -189,7 +190,7 @@ func (s *Server) bblfshComponent(port int) (*Component, error) {
 	return &Component{
 		Name: bblfshd.Name,
 		Start: createBbblfshd(
-			docker.WithPort(port, bblfshParsePort),
+			docker.WithPort(port, components.BblfshParsePort),
 		),
 	}, nil
 }

--- a/cmd/srcd-server/engine/drivers.go
+++ b/cmd/srcd-server/engine/drivers.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/src-d/engine/api"
+	"github.com/src-d/engine/components"
 	"google.golang.org/grpc"
 )
 
@@ -18,7 +19,7 @@ func (s *Server) bblfshDriverClient(ctx context.Context) (drivers.ProtocolServic
 		return nil, err
 	}
 
-	addr := fmt.Sprintf("%s:%d", bblfshd.Name, bblfshControlPort)
+	addr := fmt.Sprintf("%s:%d", bblfshd.Name, components.BblfshControlPort)
 	logrus.Infof("connecting to bblfsh management on %s", addr)
 	conn, err := grpc.Dial(addr, grpc.WithInsecure())
 	if err != nil {

--- a/cmd/srcd-server/engine/parse.go
+++ b/cmd/srcd-server/engine/parse.go
@@ -18,11 +18,6 @@ import (
 	enry "gopkg.in/src-d/enry.v1"
 )
 
-const (
-	bblfshParsePort   = 9432
-	bblfshControlPort = 9433
-)
-
 var bblfshd = components.Bblfshd
 
 type logf func(format string, args ...interface{})
@@ -67,7 +62,7 @@ func (s *Server) parse(ctx context.Context, req *api.ParseRequest, log logf) (*a
 		return nil, err
 	}
 
-	addr := fmt.Sprintf("%s:%d", bblfshd.Name, bblfshParsePort)
+	addr := fmt.Sprintf("%s:%d", bblfshd.Name, components.BblfshParsePort)
 	log("connecting to bblfsh parsing on %s", addr)
 	client, err := bblfsh.NewClient(addr)
 	if err != nil {
@@ -130,7 +125,9 @@ func createBbblfshd(opts ...docker.ConfigOption) docker.StartFunc {
 
 		config := &container.Config{
 			Image: bblfshd.ImageWithVersion(),
-			Cmd:   []string{"-ctl-address=0.0.0.0:9433", "-ctl-network=tcp"},
+			Cmd: []string{
+				fmt.Sprintf("-ctl-address=0.0.0.0:%d", components.BblfshControlPort),
+				"-ctl-network=tcp"},
 		}
 
 		host := &container.HostConfig{Privileged: true}

--- a/cmd/srcd-server/engine/sql.go
+++ b/cmd/srcd-server/engine/sql.go
@@ -16,7 +16,6 @@ import (
 )
 
 const (
-	gitbasePort           = 3306
 	gitbaseMountPath      = "/opt/repos"
 	gitbaseIndexMountPath = "/var/lib/gitbase/index"
 )
@@ -97,7 +96,7 @@ func createGitbase(opts ...docker.ConfigOption) docker.StartFunc {
 		config := &container.Config{
 			Image: gitbase.ImageWithVersion(),
 			Env: []string{
-				fmt.Sprintf("BBLFSH_ENDPOINT=%s:%d", bblfshd.Name, bblfshParsePort),
+				fmt.Sprintf("BBLFSH_ENDPOINT=%s:%d", bblfshd.Name, components.BblfshParsePort),
 			},
 		}
 		host := &container.HostConfig{}

--- a/cmd/srcd-server/engine/web.go
+++ b/cmd/srcd-server/engine/web.go
@@ -11,11 +11,7 @@ import (
 	"github.com/src-d/engine/docker"
 )
 
-const (
-	gitbaseWebPrivatePort = 8080
-	gitbaseWebSelectLimit = 0
-	bblfshWebPrivatePort  = 8080
-)
+const gitbaseWebSelectLimit = 0
 
 var (
 	gitbaseWeb = components.GitbaseWeb
@@ -35,7 +31,7 @@ func createBblfshWeb(opts ...docker.ConfigOption) docker.StartFunc {
 
 		config := &container.Config{
 			Image: bblfshWeb.ImageWithVersion(),
-			Cmd:   []string{fmt.Sprintf("-bblfsh-addr=%s:%d", bblfshd.Name, bblfshParsePort)},
+			Cmd:   []string{fmt.Sprintf("-bblfsh-addr=%s:%d", bblfshd.Name, components.BblfshParsePort)},
 		}
 		host := &container.HostConfig{
 			// TODO(erizocosmico): Bblfsh web tries to connect to bblfsh before
@@ -64,8 +60,8 @@ func createGitbaseWeb(opts ...docker.ConfigOption) docker.StartFunc {
 			Image: gitbaseWeb.ImageWithVersion(),
 			Env: []string{
 				fmt.Sprintf("GITBASEPG_DB_CONNECTION=root@tcp(%s)/none?maxAllowedPacket=4194304", gitbase.Name),
-				fmt.Sprintf("GITBASEPG_BBLFSH_SERVER_URL=%s:%d", bblfshd.Name, bblfshParsePort),
-				fmt.Sprintf("GITBASEPG_PORT=%d", gitbaseWebPrivatePort),
+				fmt.Sprintf("GITBASEPG_BBLFSH_SERVER_URL=%s:%d", bblfshd.Name, components.BblfshParsePort),
+				fmt.Sprintf("GITBASEPG_PORT=%d", components.GitbaseWebPort),
 				fmt.Sprintf("GITBASEPG_SELECT_LIMIT=%d", gitbaseWebSelectLimit),
 			},
 		}

--- a/cmd/srcd/daemon/daemon.go
+++ b/cmd/srcd/daemon/daemon.go
@@ -26,7 +26,6 @@ import (
 )
 
 const (
-	daemonPort   = "4242"
 	dockerSocket = "/var/run/docker.sock"
 	// maxMessageSize overrides default grpc max. message size to receive
 	maxMessageSize = 100 * 1024 * 1024 // 100MB
@@ -174,6 +173,8 @@ func createDaemon(workdir string) docker.StartFunc {
 
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
+
+		daemonPort := nat.Port(strconv.Itoa(components.DaemonPort))
 
 		config := &container.Config{
 			Image:        fmt.Sprintf("%s:%s", cmp.Image, cmp.Version),

--- a/components/components.go
+++ b/components/components.go
@@ -134,6 +134,24 @@ var (
 	}
 )
 
+const (
+	// BblfshParsePort is the Bblfsh private port for parse requests
+	BblfshParsePort = 9432
+	// BblfshControlPort is the Bblfsh private port for control requests
+	BblfshControlPort = 9433
+
+	// GitbaseWebPort is the GitbaseWeb private port
+	GitbaseWebPort = 8080
+	// BblfshWebPort is the BblfshWeb private port
+	BblfshWebPort = 8080
+
+	// GitbasePort is the Gitbase private port
+	GitbasePort = 3306
+
+	// DaemonPort is the Daemon private port
+	DaemonPort = 4242
+)
+
 // FilterFunc is a filtering function for List.
 type FilterFunc func(Component) (bool, error)
 


### PR DESCRIPTION
Fix #240.

Instead of api/config.go I decided to put the port definitions in components.go. The reason is because these private ports cannot be configured, they simply define the private port used by the docker images, which are also defined in components.go.

For config.go I didn't use the private port in the public port default value of GitbaseWeb and BblfshWeb. Instead of 8080 for both we use 8080 and 8081, and I think it made sense to leave them hardcoded.