### PR TITLE
Update bblfsh to v2.12.0

### DIFF
--- a/components/components.go
+++ b/components/components.go
@@ -111,7 +111,7 @@ var (
 	Bblfshd = Component{
 		Name:    "srcd-cli-bblfshd",
 		Image:   "bblfsh/bblfshd",
-		Version: "v2.11.8-drivers",
+		Version: "v2.12.0-drivers",
 	}
 
 	BblfshWeb = Component{


### PR DESCRIPTION
New bblfsh release, https://github.com/bblfsh/bblfshd/releases/tag/v2.12.0