### PR TITLE
remove prune of old gitbase indexes

### DIFF
--- a/cmd/srcd/daemon/daemon.go
+++ b/cmd/srcd/daemon/daemon.go
@@ -66,15 +66,7 @@ func Kill() error {
 
 // CleanUp removes all resources created by daemon on host
 func CleanUp() error {
-	datadir, err := datadir()
-	if err != nil {
-		return err
-	}
-
-	// TODO(max): we can remove it in engine v0.13 or later
-	gitbaseIndexDir := filepath.Join(datadir, "gitbase")
-
-	return os.RemoveAll(gitbaseIndexDir)
+	return nil
 }
 
 // Client will return a new EngineClient to interact with the daemon. If the


### PR DESCRIPTION
fix: #380

I didn't delete `CleanUp` function because I'm going to use it in state PR. And we might want to clean something else later.

I also didn't change the changelog. Because we still clean indexes on prune we just do it differently.