### PR TITLE
Deal with anonymous dangling volumes

### DIFF
--- a/cmd/srcd/cmd/prune_test.go
+++ b/cmd/srcd/cmd/prune_test.go
@@ -76,8 +76,6 @@ func (s *PruneTestSuite) TestRunningContainers() {
 	s.AllStopped()
 
 	// Test volumes with name srcd-cli-* were deleted.
-	// This does not actually test much because Engine does not create volumes
-	// since v0.7.0.
 	// The logic used in prune to delete named volumes is looking for the
 	// srcd-cli- prefix in the name, so that's what we check here.
 	vols, err := docker.ListVolumes(context.Background())
@@ -88,14 +86,7 @@ func (s *PruneTestSuite) TestRunningContainers() {
 	}
 
 	// Test anonymous volumes were deleted
-
-	// TODO (carlosms) this test fails because of
-	// https://github.com/src-d/engine/issues/371
-	// temporary assertion for the wrong values, this way the test will fail when
-	// the issue is solved. As a reminder to remove this and uncomment the right
-	// assertion
-	s.True(len(volNames(prevVols)) < len(volNames(vols)))
-	//require.Equal(volNames(prevVols), volNames(vols))
+	require.Equal(volNames(prevVols), volNames(vols))
 
 	// Test srcd-cli-network network was deleted.
 	nets, err := listNetworks()

--- a/cmd/srcd/cmd/sql.go
+++ b/cmd/srcd/cmd/sql.go
@@ -99,7 +99,10 @@ var sqlCmd = &cobra.Command{
 			}
 
 			cd := int(<-exit)
-			os.Exit(cd)
+			if cd != 0 {
+				return fmt.Errorf("MySQL exited with status %d", cd)
+			}
+
 			return nil
 		}
 


### PR DESCRIPTION
Fix #371.

There were 2 problems:
- `docker.withVolume` was creating an extra anonymous volume definition.
- the mysql docker image contains a volume definition in the image dockerfile.

I couldn't find a way to force the mysql container to start without a volume, so I added the `RemoveVolumes` option to `RemoveContainer`. It seems to apply only to the anonymous volumes, and the named volumes with index data are not deleted. This is similar to `docker rm --volumes`.

There was a problem in the `sql` command. It was using `os.Exit`, so the `defer stopMysqlClient()` was never executed. The mysql container was left stopped, and the associated volume was also not cleaned.