### PR TITLE
Fix integration tests failing for release tags

### DIFF
--- a/cmd/srcd/cmd/components_test.go
+++ b/cmd/srcd/cmd/components_test.go
@@ -123,11 +123,11 @@ func (s *ComponentsTestSuite) TestInstallAlias() {
 	require := s.Require()
 
 	// Install with image name
-	out, err := s.RunCommand(context.TODO(), "components", "install", "srcd/cli-daemon")
+	out, err := s.RunCommand(context.TODO(), "components", "install", "srcd/gitbase")
 	require.NoError(err, out.String())
 
 	// Install with container name
-	out, err = s.RunCommand(context.TODO(), "components", "install", "srcd-cli-daemon")
+	out, err = s.RunCommand(context.TODO(), "components", "install", "srcd-cli-gitbase")
 	require.NoError(err, out.String())
 }
 

--- a/cmd/srcd/cmd/init_test.go
+++ b/cmd/srcd/cmd/init_test.go
@@ -97,7 +97,6 @@ func (s *InitTestSuite) TestWithoutWorkdir() {
 	require.NoError(err)
 
 	actualMsg := s.getLogMessages(buf)
-	require.Equal(2, len(actualMsg))
 
 	workdir, _ := os.Getwd()
 	expectedMsg := [2]string{
@@ -105,8 +104,8 @@ func (s *InitTestSuite) TestWithoutWorkdir() {
 		"daemon started",
 	}
 
-	for i, exp := range expectedMsg {
-		require.Equal(exp, actualMsg[i])
+	for _, exp := range expectedMsg {
+		require.Contains(actualMsg, exp)
 	}
 }
 
@@ -117,15 +116,14 @@ func (s *InitTestSuite) TestWithValidWorkdir() {
 	require.NoError(err)
 
 	actualMsg := s.getLogMessages(buf)
-	require.Equal(2, len(actualMsg))
 
 	expectedMsg := [2]string{
 		fmt.Sprintf("starting daemon with working directory: %s", s.validWorkDir),
 		"daemon started",
 	}
 
-	for i, exp := range expectedMsg {
-		require.Equal(exp, actualMsg[i])
+	for _, exp := range expectedMsg {
+		require.Contains(actualMsg, exp)
 	}
 }
 
@@ -157,7 +155,6 @@ func (s *InitTestSuite) TestWithRunningDaemon() {
 	require.NoError(err)
 
 	actualMsg := s.getLogMessages(buf)
-	require.Equal(3, len(actualMsg))
 
 	expectedMsg := [3]string{
 		fmt.Sprintf("removing container %s", components.Daemon.Name),
@@ -165,8 +162,8 @@ func (s *InitTestSuite) TestWithRunningDaemon() {
 		"daemon started",
 	}
 
-	for i, exp := range expectedMsg {
-		require.Equal(exp, actualMsg[i])
+	for _, exp := range expectedMsg {
+		require.Contains(actualMsg, exp)
 	}
 }
 
@@ -183,7 +180,6 @@ func (s *InitTestSuite) TestWithRunningOtherComponents() {
 	require.NoError(err)
 
 	actualMsg := s.getLogMessages(buf)
-	require.Equal(5, len(actualMsg))
 
 	expectedMsg := [5]string{
 		fmt.Sprintf("removing container %s", components.Bblfshd.Name),
@@ -193,8 +189,8 @@ func (s *InitTestSuite) TestWithRunningOtherComponents() {
 		"daemon started",
 	}
 
-	for i, exp := range expectedMsg {
-		require.Equal(exp, actualMsg[i])
+	for _, exp := range expectedMsg {
+		require.Contains(actualMsg, exp)
 	}
 }
 

--- a/cmd/srcd/cmd/parse_test.go
+++ b/cmd/srcd/cmd/parse_test.go
@@ -131,7 +131,7 @@ func (s *ParseTestSuite) TestLang() {
 			require := require.New(t)
 
 			// Check the language is detected
-			out, err := s.RunCommand(context.TODO(), "parse", "lang", tc.path)
+			out, err := s.runCommandStdout(context.TODO(), "parse", "lang", tc.path)
 			require.NoError(err, out.String())
 			require.Equal(tc.lang+"\n", out.String())
 		})

--- a/docker/dockerhub.go
+++ b/docker/dockerhub.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"strings"
 	"time"
 
 	"github.com/blang/semver"
@@ -18,11 +17,6 @@ func GetCompatibleTag(image, currentVersion string) (string, bool, error) {
 	// For go run
 	if currentVersion == "" || currentVersion == "dev" {
 		return "latest", false, nil
-	}
-
-	// For local builds without a release tag, e.g. dev-5045ba7-dirty
-	if strings.HasPrefix(currentVersion, "dev") {
-		return currentVersion, false, nil
 	}
 
 	cliV, err := semver.ParseTolerant(currentVersion)


### PR DESCRIPTION
Fix #392.

When a build was done with version `dev-xxxx` the code did no go to dockerhub to look for newer releases. 
But when the release tag was created, the tests on travis use a real semver tag before the image is uploaded to dockerhub. Some tests failed because in this case there is a warning message:
```
WARN[0009] unable to list the available daemon versions on Docker Hub: can't find compatible image in docker registry for srcd/cli-daemon 
```

In this PR I have removed the special case for `dev-xxxx` versions, and I have updated tests to not rely on the exact output logs.