### PR TITLE
Adds integration testing for prune --with-images command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ jobs:
 
     - name: 'Integration Tests Linux'
       script:
-        - make test-integration
+        - TEST_PRUNE_WITH_IMAGE=true make test-integration
     - name: 'Generated code'
       script:
         - GO111MODULE=on go mod tidy

--- a/Makefile
+++ b/Makefile
@@ -9,13 +9,15 @@ CI_REPOSITORY ?= https://github.com/src-d/ci.git
 CI_PATH ?= $(shell pwd)/.ci
 CI_VERSION ?= v1
 
+TEST_PRUNE_WITH_IMAGE ?= false
+
 MAKEFILE := $(CI_PATH)/Makefile.main
 $(MAKEFILE):
 	git clone --quiet --branch $(CI_VERSION) --depth 1 $(CI_REPOSITORY) $(CI_PATH);
 
 -include $(MAKEFILE)
 
-GOTEST_INTEGRATION = $(GOTEST) -parallel 1 -count 1 -tags=integration -ldflags "$(LD_FLAGS)"
+GOTEST_INTEGRATION = $(GOTEST) -timeout 20m -parallel 1 -count 1 -tags=integration -ldflags "$(LD_FLAGS)"
 
 OS := $(shell uname)
 
@@ -30,6 +32,7 @@ test-integration-clean:
 endif
 
 test-integration-no-build: test-integration-clean
-	$(GOTEST_INTEGRATION) github.com/src-d/engine/cmdtests/
+	TEST_PRUNE_WITH_IMAGE=false $(GOTEST_INTEGRATION) github.com/src-d/engine/cmdtests/
+	$(GOTEST_INTEGRATION) github.com/src-d/engine/cmdtests/ -run TestPruneTestSuite/TestRunningContainersWithImages
 
 test-integration: clean build docker-build test-integration-no-build

--- a/cmdtests/prune_test.go
+++ b/cmdtests/prune_test.go
@@ -4,34 +4,35 @@ package cmdtests_test
 
 import (
 	"context"
+	"os"
 	"sort"
 	"testing"
 
 	"github.com/src-d/engine/cmdtests"
+	"github.com/src-d/engine/components"
 	"github.com/src-d/engine/docker"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
-// This test suite does not test the `--with-images` flag.
+// This test suite by default does not test the `--with-images` flag.
 // If the tests are run with `make test-integration` the daemon image will be
 // the one build locally (e.g. srcd/cli-daemon:dev-b72f1fe), and deleting
 // this image would make all the other tests fail.
+// Running the tests with `TEST_PRUNE_WITH_IMAGE=true make test-integration`
+// will run the test with `--with-images` flag as last in order to avoid the
+// aforementioned problem.
 
 type PruneTestSuite struct {
 	cmdtests.IntegrationTmpDirSuite
 }
 
-func TestPruneTestSuite(t *testing.T) {
-	s := PruneTestSuite{}
-	suite.Run(t, &s)
-}
-
-func (s *PruneTestSuite) TestRunningContainers() {
-	require := s.Require()
+func (s *PruneTestSuite) testRunningContainers(require *require.Assertions, withImages bool) {
+	s.T().Helper()
 
 	// Get the list of volumes and networks before calling init
 	prevVols, err := docker.ListVolumes(context.Background())
@@ -46,7 +47,12 @@ func (s *PruneTestSuite) TestRunningContainers() {
 	r = s.RunCommand("sql", "SELECT 1")
 	require.NoError(r.Error, r.Combined())
 
-	r = s.RunCommand("prune")
+	if withImages {
+		r = s.RunCommand("prune", "--with-images")
+	} else {
+		r = s.RunCommand("prune")
+	}
+
 	require.NoError(r.Error, r.Combined())
 
 	// Test containers were deleted
@@ -77,6 +83,56 @@ func (s *PruneTestSuite) TestRunningContainers() {
 	require.Equal(netNames(prevNets), netNames(nets))
 }
 
+func (s *PruneTestSuite) TestRunningContainers() {
+	s.testRunningContainers(s.Require(), false)
+}
+
+func (s *PruneTestSuite) TestStoppedContainers() {
+	require := s.Require()
+
+	r := s.RunCommand("prune")
+	require.NoError(r.Error, r.Combined())
+}
+
+func (s *PruneTestSuite) TestRunningContainersWithImages() {
+	if os.Getenv("TEST_PRUNE_WITH_IMAGE") != "true" {
+		s.T().Skip("Use env var TEST_PRUNE_WITH_IMAGE=true to test srcd prune with --with-images flag")
+	}
+
+	s.testRunningContainers(s.Require(), true)
+	s.requireNoImages()
+}
+
+func (s *PruneTestSuite) requireNoImages() {
+	s.T().Helper()
+	require := s.Require()
+
+	images, _ := docker.ListImages(context.Background())
+	imagesNames := make(map[string]components.Component)
+	for _, c := range []components.Component{
+		components.Daemon,
+		components.Gitbase,
+		components.GitbaseWeb,
+		components.MysqlCli,
+		components.Bblfshd,
+		components.BblfshWeb,
+	} {
+		imagesNames[c.Image] = c
+	}
+
+	for _, i := range images {
+		for _, rt := range i.RepoTags {
+			img, _ := docker.SplitImageID(rt)
+			comp, ok := imagesNames[img]
+			require.Falsef(ok, "Image with repo tag '%s' shouldn't be present for component '%s'", rt, comp.Name)
+		}
+	}
+}
+
+func TestPruneTestSuite(t *testing.T) {
+	suite.Run(t, &PruneTestSuite{})
+}
+
 func volNames(volumes []*docker.Volume) []string {
 	var names []string
 	for _, vol := range volumes {
@@ -104,11 +160,4 @@ func listNetworks() ([]types.NetworkResource, error) {
 	}
 
 	return c.NetworkList(context.Background(), types.NetworkListOptions{})
-}
-
-func (s *PruneTestSuite) TestStoppedContainers() {
-	require := s.Require()
-
-	r := s.RunCommand("prune")
-	require.NoError(r.Error, r.Combined())
 }

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -170,17 +170,12 @@ func IsInstalled(ctx context.Context, image, version string) (bool, error) {
 // VersionsInstalled returns a list of versions installed for the given image
 // name
 func VersionsInstalled(ctx context.Context, image string) ([]string, error) {
-	c, err := client.NewEnvClient()
-	if err != nil {
-		return nil, errors.Wrap(err, "could not create docker client")
-	}
-
 	ctx, cancel := context.WithTimeout(ctx, time.Second)
 	defer cancel()
 
-	imgs, err := c.ImageList(ctx, types.ImageListOptions{})
+	imgs, err := ListImages(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not list images")
+		return nil, err
 	}
 
 	res := make([]string, 0)
@@ -456,6 +451,22 @@ func ListVolumes(ctx context.Context) ([]*Volume, error) {
 	}
 
 	return list.Volumes, nil
+}
+
+type Image = types.ImageSummary
+
+func ListImages(ctx context.Context) ([]Image, error) {
+	cli, err := client.NewEnvClient()
+	if err != nil {
+		return nil, errors.Wrap(err, "could not create docker client")
+	}
+
+	images, err := cli.ImageList(ctx, types.ImageListOptions{})
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get list of images")
+	}
+
+	return images, nil
 }
 
 func RemoveVolume(ctx context.Context, id string) error {


### PR DESCRIPTION
Closes #374.

Adds integration testing for the `srcd prune --with-images` and runs it on CI. Running this test is disabled by default and can be enabled by settings the env var `TEST_PRUNE_WITH_IMAGE=true` as in [here](https://github.com/src-d/engine/pull/405/files#diff-354f30a63fb0907d4ad57269548329e3R35).