### PR TITLE
Adds an utility to print tables

### DIFF
--- a/cmd/srcd/cmd/components.go
+++ b/cmd/srcd/cmd/components.go
@@ -20,7 +20,6 @@ import (
 	"log"
 	"os"
 	"strings"
-	"text/tabwriter"
 
 	"github.com/spf13/cobra"
 	"github.com/src-d/engine/components"
@@ -47,11 +46,10 @@ var componentsListCmd = &cobra.Command{
 			return humanizef(err, "could not list images")
 		}
 
-		w := tabwriter.NewWriter(os.Stdout, 0, 0, 4, ' ', 0)
-		fmt.Fprintf(w, "IMAGE\tINSTALLED\tRUNNING\tPORT\tCONTAINER NAME\n")
-
+		t := NewTable("%s", "%s", "%v", "%v", "%v")
+		t.Header("IMAGE", "INSTALLED", "RUNNING", "PORT", "CONTAINER NAME")
 		for _, cmp := range cmps {
-			fmt.Fprintf(w, "%s\t%s\t%v\t%v\t%v\n",
+			t.Row(
 				cmp.ImageWithVersion(),
 				boolFmt(cmp.IsInstalled()),
 				boolFmt(cmp.IsRunning()),
@@ -60,8 +58,7 @@ var componentsListCmd = &cobra.Command{
 			)
 		}
 
-		w.Flush()
-		return nil
+		return t.Print(os.Stdout)
 	},
 }
 

--- a/cmd/srcd/cmd/drivers.go
+++ b/cmd/srcd/cmd/drivers.go
@@ -2,9 +2,7 @@ package cmd
 
 import (
 	"context"
-	"fmt"
 	"os"
-	"text/tabwriter"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -30,16 +28,14 @@ var parseDriversListCmd = &cobra.Command{
 			return humanizef(err, "could not list drivers")
 		}
 
-		w := new(tabwriter.Writer)
-		defer w.Flush()
-		w.Init(os.Stdout, 0, 8, 5, '\t', 0)
-		fmt.Fprintln(w, "LANGUAGE\tVERSION")
-		fmt.Fprintln(w, "----------\t----------")
+		t := NewTable("%s", "%s")
+		t.Header("LANGUAGE", "VERSION")
 		for _, driver := range drivers.Drivers {
-			fmt.Fprintf(w, "%s\t%s\n", driver.Lang, driver.Version)
+			t.Row(driver.Lang, driver.Version)
 		}
 
-		return nil
+		return t.Print(os.Stdout)
+
 	},
 }
 

--- a/cmd/srcd/cmd/table.go
+++ b/cmd/srcd/cmd/table.go
@@ -7,20 +7,27 @@ import (
 	"text/tabwriter"
 )
 
+// Table represents a printable table composed by rows and an optional header
 type Table struct {
 	formats []string
 	header  []string
 	rows    [][]interface{}
 }
 
+// Header sets the header of the table with the given strings
 func (t *Table) Header(header ...string) {
 	t.header = header
 }
 
+// Row adds a row to the table
 func (t *Table) Row(row ...interface{}) {
 	t.rows = append(t.rows, row)
 }
 
+// Print prints the table to the given writer
+// It returns an error if there's a mismatch between the length of the formats
+// and the length of the header, or between the length of the formats and the
+// length of any row.
 func (t *Table) Print(output io.Writer) error {
 	tw := tabwriter.NewWriter(output, 0, 0, 4, ' ', 0)
 	if len(t.header) > 0 {
@@ -46,6 +53,7 @@ func (t *Table) Print(output io.Writer) error {
 	return tw.Flush()
 }
 
+// NewTable creates a new `Table` with the provided formats
 func NewTable(formats ...string) *Table {
 	return &Table{formats: formats}
 }

--- a/cmd/srcd/cmd/table.go
+++ b/cmd/srcd/cmd/table.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+)
+
+type Table struct {
+	formats []string
+	header  []string
+	rows    [][]interface{}
+}
+
+func (t *Table) Header(header ...string) error {
+	if len(header) != len(t.formats) {
+		return fmt.Errorf("number of header provided '%d', required '%d'",
+			len(header), len(t.formats))
+	}
+
+	t.header = header
+	return nil
+}
+
+func (t *Table) Row(row ...interface{}) error {
+	if len(row) != len(t.formats) {
+		return fmt.Errorf("number of items provided '%d', required '%d'",
+			len(row), len(t.formats))
+	}
+
+	t.rows = append(t.rows, row)
+	return nil
+}
+
+func (t *Table) Print(output io.Writer) error {
+	tw := tabwriter.NewWriter(output, 0, 0, 4, ' ', 0)
+	if len(t.header) > 0 {
+		sHeader := strings.Join(t.header, "\t") + "\n"
+		fmt.Fprintf(tw, sHeader)
+	}
+
+	sFormats := strings.Join(t.formats, "\t") + "\n"
+	for _, row := range t.rows {
+		fmt.Fprintf(tw, sFormats, row...)
+	}
+
+	return tw.Flush()
+}
+
+func NewTable(formats ...string) *Table {
+	return &Table{formats: formats}
+}

--- a/cmd/srcd/cmd/table.go
+++ b/cmd/srcd/cmd/table.go
@@ -13,35 +13,33 @@ type Table struct {
 	rows    [][]interface{}
 }
 
-func (t *Table) Header(header ...string) error {
-	if len(header) != len(t.formats) {
-		return fmt.Errorf("number of header provided '%d', required '%d'",
-			len(header), len(t.formats))
-	}
-
+func (t *Table) Header(header ...string) {
 	t.header = header
-	return nil
 }
 
-func (t *Table) Row(row ...interface{}) error {
-	if len(row) != len(t.formats) {
-		return fmt.Errorf("number of items provided '%d', required '%d'",
-			len(row), len(t.formats))
-	}
-
+func (t *Table) Row(row ...interface{}) {
 	t.rows = append(t.rows, row)
-	return nil
 }
 
 func (t *Table) Print(output io.Writer) error {
 	tw := tabwriter.NewWriter(output, 0, 0, 4, ' ', 0)
 	if len(t.header) > 0 {
+		if len(t.header) != len(t.formats) {
+			return fmt.Errorf("number of header provided '%d', required '%d'",
+				len(t.header), len(t.formats))
+		}
+
 		sHeader := strings.Join(t.header, "\t") + "\n"
 		fmt.Fprintf(tw, sHeader)
 	}
 
 	sFormats := strings.Join(t.formats, "\t") + "\n"
 	for _, row := range t.rows {
+		if len(row) != len(t.formats) {
+			return fmt.Errorf("number of items in row provided '%d', required '%d'",
+				len(row), len(t.formats))
+		}
+
 		fmt.Fprintf(tw, sFormats, row...)
 	}
 

--- a/cmd/srcd/cmd/table_test.go
+++ b/cmd/srcd/cmd/table_test.go
@@ -1,0 +1,84 @@
+// +build !integration
+
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type TableTestSuite struct {
+	suite.Suite
+}
+
+func TestTableTestSuite(t *testing.T) {
+	suite.Run(t, new(TableTestSuite))
+}
+
+func (s *TableTestSuite) TestPrintWrongSize() {
+	require := s.Require()
+
+	t := NewTable("%s", "%d", "%b")
+	require.Error(t.Header("col1"))
+	require.Error(t.Row("f1", "f2"))
+}
+
+func (s *TableTestSuite) sampleFixture() ([]string, []string, [][]interface{}) {
+	formats := []string{"%s", "%d", "%b"}
+	header := []string{"col1", "col2", "col3"}
+	rows := [][]interface{}{
+		[]interface{}{"s1", 1, 1},
+		[]interface{}{"s2", 2, 2},
+		[]interface{}{"s3", 3, 3},
+		[]interface{}{"s4", 4, 4},
+		[]interface{}{"s5", 5, 5},
+	}
+
+	return formats, header, rows
+}
+
+func (s *TableTestSuite) TestPrint() {
+	require := s.Require()
+
+	var out bytes.Buffer
+	formats, header, rows := s.sampleFixture()
+
+	t := NewTable(formats...)
+	require.NoError(t.Header(header...))
+	for _, r := range rows {
+		require.NoError(t.Row(r...))
+	}
+
+	require.NoError(t.Print(&out))
+	expected := `col1    col2    col3
+s1      1       1
+s2      2       10
+s3      3       11
+s4      4       100
+s5      5       101
+`
+	require.Equal(expected, out.String())
+}
+
+func (s *TableTestSuite) TestPrintNoHeader() {
+	require := s.Require()
+
+	var out bytes.Buffer
+	formats, _, rows := s.sampleFixture()
+
+	t := NewTable(formats...)
+	for _, r := range rows {
+		require.NoError(t.Row(r...))
+	}
+
+	require.NoError(t.Print(&out))
+	expected := `s1    1    1
+s2    2    10
+s3    3    11
+s4    4    100
+s5    5    101
+`
+	require.Equal(expected, out.String())
+}

--- a/cmdtests/parse_test.go
+++ b/cmdtests/parse_test.go
@@ -92,17 +92,16 @@ func (s *ParseTestSuite) TestDriversList() {
 
 	/* Example output:
 
-	LANGUAGE	VERSION
-	----------	----------
-	python		v2.8.0
-	cpp		v1.1.0
-	java		v2.5.0
-	javascript	v2.6.0
-	bash		v2.4.0
-	ruby		v2.9.0
-	go		v2.5.0
-	csharp		v1.4.0
-	php		v2.7.0
+	LANGUAGE      VERSION
+	python        v2.8.2
+	cpp           v1.2.3
+	java          v2.6.2
+	javascript    v2.7.2
+	bash          v2.5.1
+	ruby          v2.9.2
+	go            v2.5.2
+	csharp        v1.4.2
+	php           v2.7.3
 	*/
 
 	// Simple checks to see if it's the table, and contains a known driver


### PR DESCRIPTION
Closes #322.

This adds two functions `PrintTable` and `PrintDefaultTable`. This simplifies table printing and helps to have a consistent styling for all of them. It's also easier to eventually change the style of all tables.