### PR TITLE
New command srcd config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,13 +20,14 @@
 
 ### New Features
 
+- New `srcd config` command. A convenient way to open your `~/.srcd/config.yml` file, populating it with the default config values if it is empty ([#422](https://github.com/src-d/engine/issues/422)).
 - The `srcd` commands now have the following new options for log messages ([#410](https://github.com/src-d/engine/issues/410)):
-```
---log-level=[info|debug|warning|error] Logging level (default: info) [$LOG_LEVEL]
---log-format=[text|json]               log format, defaults to text on a terminal and json otherwise [$LOG_FORMAT]
---log-fields=                          default fields for the logger, specified in json [$LOG_FIELDS]
---log-force-format                     ignore if it is running on a terminal or not [$LOG_FORCE_FORMAT]
-```
+  ```
+  --log-level=[info|debug|warning|error] Logging level (default: info) [$LOG_LEVEL]
+  --log-format=[text|json]               log format, defaults to text on a terminal and json otherwise [$LOG_FORMAT]
+  --log-fields=                          default fields for the logger, specified in json [$LOG_FIELDS]
+  --log-force-format                     ignore if it is running on a terminal or not [$LOG_FORCE_FORMAT]
+  ```
 
 ### Bug Fixes
 

--- a/cmd/srcd/cmd/config.go
+++ b/cmd/srcd/cmd/config.go
@@ -1,0 +1,98 @@
+package cmd
+
+import (
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/src-d/engine/cmd/srcd/config"
+	"gopkg.in/src-d/go-log.v1"
+)
+
+// configCmd represents the config command
+type configCmd struct {
+	Command `name:"config" short-description:"Edit the config file" long-description:"Edit the config file.\n\nIf the config file is empty it will be populated with the default values.\nSet EDITOR env var to change the text editor command."`
+}
+
+func (c *configCmd) Execute(args []string) error {
+	cmdName := os.Getenv("VISUAL")
+	if cmdName == "" {
+		cmdName = os.Getenv("EDITOR")
+	}
+
+	if cmdName == "" {
+		if runtime.GOOS == "windows" {
+			cmdName = "start" // opens the default editor
+		} else {
+			cmdName = "nano"
+		}
+
+		log.Debugf("EDITOR is not set, using command %s", cmdName)
+	}
+
+	configFile := c.Config
+	if configFile == "" {
+		var err error
+		configFile, err = config.DefaultPath()
+		if err != nil {
+			return err
+		}
+	}
+
+	emptyFile, err := isEmptyFile(configFile)
+	if err != nil {
+		return humanizef(err, "could not read config file contents")
+	}
+
+	if emptyFile {
+		dir := filepath.Dir(configFile)
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return humanizef(err, "can't create config directory")
+		}
+
+		err = ioutil.WriteFile(configFile, []byte(config.DefaultFileContents), 0644)
+		if err != nil {
+			return humanizef(err, "could not write on config file")
+		}
+	}
+
+	cmd := exec.Command(cmdName, configFile)
+	cmd.Stdout = os.Stdout
+	cmd.Stdin = os.Stdin
+	cmd.Stderr = os.Stderr
+	err = cmd.Run()
+
+	if err != nil {
+		return humanizef(err, "could not launch the editor, please open %s with your preferred editor", configFile)
+	}
+
+	return nil
+}
+
+func init() {
+	rootCmd.AddCommand(&configCmd{})
+}
+
+// isEmptyFile returns true if the file does not exist or if it exists but
+// contains empty text
+func isEmptyFile(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return false, err
+		}
+
+		return true, nil
+	}
+
+	contents, err := ioutil.ReadFile(path)
+	if err != nil {
+		return false, err
+	}
+
+	strContents := string(contents)
+	return strings.TrimSpace(strContents) == "", nil
+}

--- a/cmd/srcd/config/config.go
+++ b/cmd/srcd/config/config.go
@@ -13,6 +13,26 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
+// DefaultFileContents is the default text for an empty config.yml file
+const DefaultFileContents = `# Any change in the exposed ports will require you to run srcd init (or stop)
+
+components:
+  bblfshd:
+    port: 9432
+
+  bblfsh_web:
+    port: 8081
+
+  gitbase_web:
+    port: 8080
+
+  gitbase:
+    port: 3306
+
+  daemon:
+    port: 4242
+`
+
 // File contains the config read from the file path used in Read
 var File = &api.Config{}
 
@@ -22,13 +42,10 @@ var File = &api.Config{}
 // is nil
 func Read(configFile string) error {
 	if configFile == "" {
-		// Find home directory.
-		home, err := homedir.Dir()
-		if err != nil {
-			return errors.Wrapf(err, "could not detect home directory")
+		var err error
+		if configFile, err = DefaultPath(); err != nil {
+			return err
 		}
-
-		configFile = filepath.Join(home, ".srcd", "config.yml")
 
 		if _, err := os.Stat(configFile); os.IsNotExist(err) {
 			return nil
@@ -48,4 +65,14 @@ func Read(configFile string) error {
 	}
 
 	return nil
+}
+
+// DefaultPath returns the default config file path, $HOME/.srcd/config.yml
+func DefaultPath() (string, error) {
+	homedir, err := homedir.Dir()
+	if err != nil {
+		return "", errors.Wrap(err, "could not detect home directory")
+	}
+
+	return filepath.Join(homedir, ".srcd", "config.yml"), nil
 }

--- a/cmdtests/config_test.go
+++ b/cmdtests/config_test.go
@@ -1,0 +1,165 @@
+// +build integration
+
+package cmdtests_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/src-d/engine/cmd/srcd/config"
+	"github.com/src-d/engine/cmdtests"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type ConfigTestSuite struct {
+	cmdtests.IntegrationTmpDirSuite
+}
+
+func TestConfigTestSuite(t *testing.T) {
+	s := ConfigTestSuite{IntegrationTmpDirSuite: cmdtests.NewIntegrationTmpDirSuite()}
+	suite.Run(t, &s)
+}
+
+func (s *ConfigTestSuite) SetupSuite() {
+	// Instead of doing complicated things to test an interactive text editor,
+	// using 'cat' we can capture the output
+	os.Setenv("EDITOR", "cat")
+}
+
+func (s *ConfigTestSuite) SetupTest() {
+	s.IntegrationTmpDirSuite.SetupTest()
+
+	// To test $HOME/.srcd/config.yml without breaking any existing installation
+	tmpHome := filepath.Join(s.TestDir, "home")
+	os.RemoveAll(tmpHome)
+	os.Setenv("HOME", tmpHome)
+}
+
+func (s *ConfigTestSuite) TestNonExistingFile() {
+	newPath := filepath.Join(s.TestDir, "new.yml")
+	defaultPath := filepath.Join(s.TestDir, "home", ".srcd", "config.yml")
+
+	testCases := []struct {
+		name string
+		path string
+		args []string
+	}{
+		{
+			name: "with --config",
+			path: newPath,
+			args: []string{"--config", newPath},
+		},
+		{
+			name: "with defaults",
+			path: defaultPath,
+		},
+	}
+
+	for _, tc := range testCases {
+		s.T().Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+
+			r := s.RunCommand("config", tc.args...)
+			require.NoError(r.Error, r.Combined())
+
+			require.Equal(config.DefaultFileContents, r.Stdout())
+
+			contents, err := ioutil.ReadFile(tc.path)
+			require.NoError(err)
+			require.Equal(config.DefaultFileContents, string(contents))
+		})
+	}
+}
+
+func (s *ConfigTestSuite) TestEmptyFile() {
+	emptyPath := filepath.Join(s.TestDir, "empty.yml")
+	defaultPath := filepath.Join(s.TestDir, "home", ".srcd", "config.yml")
+
+	dir := filepath.Dir(defaultPath)
+	err := os.MkdirAll(dir, 0755)
+	s.Require().NoError(err)
+
+	testCases := []struct {
+		name string
+		path string
+		args []string
+	}{
+		{
+			name: "with --config",
+			path: emptyPath,
+			args: []string{"--config", emptyPath},
+		},
+		{
+			name: "with defaults",
+			path: defaultPath,
+		},
+	}
+
+	for _, tc := range testCases {
+		s.T().Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+
+			err := ioutil.WriteFile(tc.path, []byte("\n"), 0644)
+			require.NoError(err)
+
+			r := s.RunCommand("config", tc.args...)
+			require.NoError(r.Error, r.Combined())
+
+			require.Equal(config.DefaultFileContents, r.Stdout())
+
+			contents, err := ioutil.ReadFile(tc.path)
+			require.NoError(err)
+			require.Equal(config.DefaultFileContents, string(contents))
+		})
+	}
+}
+
+func (s *ConfigTestSuite) TestExistingFile() {
+	existingPath := filepath.Join(s.TestDir, "filled.yml")
+	defaultPath := filepath.Join(s.TestDir, "home", ".srcd", "config.yml")
+
+	dir := filepath.Dir(defaultPath)
+	err := os.MkdirAll(dir, 0755)
+	s.Require().NoError(err)
+
+	testCases := []struct {
+		name string
+		path string
+		args []string
+	}{
+		{
+			name: "with --config",
+			path: existingPath,
+			args: []string{"--config", existingPath},
+		},
+		{
+			name: "with defaults",
+			path: defaultPath,
+		},
+	}
+
+	st := `components:
+  bblfshd:
+    port: 1234`
+
+	for _, tc := range testCases {
+		s.T().Run(tc.name, func(t *testing.T) {
+			require := require.New(t)
+
+			err := ioutil.WriteFile(tc.path, []byte(st), 0644)
+			require.NoError(err)
+
+			r := s.RunCommand("config", tc.args...)
+			require.NoError(r.Error, r.Combined())
+
+			require.Equal(st, r.Stdout())
+
+			contents, err := ioutil.ReadFile(tc.path)
+			require.NoError(err)
+			require.Equal(st, string(contents))
+		})
+	}
+}


### PR DESCRIPTION
Fix #422.

I only knew about `EDITOR` env var. Apparently for historic reasons many programs look first for an editor set in `VISUAL`, and fall back to `EDITOR` if that one is not set.

If there isn't an editor set I chose to use `nano` for macos and linux. It should be installed by default, and if you don't have an editor preference `nano` will be more user friendly than `vim` or `emacs`.