### PR TITLE
srcd parse: do not check the list of languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,13 @@
 
 - The commands fail gracefully if an incompatible Docker installation is found, such as Docker Toolbox  ([#417](https://github.com/src-d/engine/issues/417)).
 
+### Known Issues
+
+- [#297](https://github.com/src-d/engine/issues/297): `srcd parse` does not detect the language automatically for bash files. For this language you will need to set `--lang` manually. For example:
+```
+$ srcd parse uast file.bash --lang bash
+```
+
 </details>
 
 ## [v0.12.0](https://github.com/src-d/engine/releases/tag/v0.12.0) - 2019-04-04

--- a/cmdtests/parse_test.go
+++ b/cmdtests/parse_test.go
@@ -42,11 +42,14 @@ var testCases = []testCase{
 		filename: "hello-py3.py",
 		lang:     "python",
 	},
-	{
-		path:     filepath.FromSlash("testdata/hello.cpp"),
-		filename: "hello.cpp",
-		lang:     "c++",
-	},
+	// Disabled cpp parsing, see https://github.com/bblfsh/cpp-driver/issues/31
+	/*
+		{
+			path:     filepath.FromSlash("testdata/hello.cpp"),
+			filename: "hello.cpp",
+			lang:     "c++",
+		},
+	*/
 	{
 		path:     filepath.FromSlash("testdata/hello.java"),
 		filename: "hello.java",
@@ -72,11 +75,14 @@ var testCases = []testCase{
 		filename: "hello.go",
 		lang:     "go",
 	},
-	{
-		path:     filepath.FromSlash("testdata/hello.cs"),
-		filename: "hello.cs",
-		lang:     "c#",
-	},
+	// Disabled csharp parsing, see https://github.com/bblfsh/bblfshd/issues/259
+	/*
+		{
+			path:     filepath.FromSlash("testdata/hello.cs"),
+			filename: "hello.cs",
+			lang:     "c#",
+		},
+	*/
 	{
 		path:     filepath.FromSlash("testdata/hello.php"),
 		filename: "hello.php",
@@ -177,7 +183,7 @@ func (s *ParseTestSuite) TestUast() {
 				// ----------------
 				// TODO Temporary test skip, it fails for cpp, bash, and csharp.
 				// See https://github.com/src-d/engine/issues/297
-				if tc.lang == "c++" || tc.lang == "shell" || tc.lang == "c#" {
+				if tc.lang == "shell" {
 					// This Error assertion will fail when #297 is fixed, to remind us to remove this skip
 					require.Error(r.Error)
 					t.Skip("TEST FAILURE IS A KNOWN ISSUE (#297): " + r.Stdout())


### PR DESCRIPTION
This is a workaround for #297.

The command now does not try to check if the file language is in the list of bblfsh drivers. But if bblfsh reports that the parsing failed because of a missing driver, engine will still print the same nice error message with the current list of supported languages.

It works for
- enry `c#` -> bblfsh `csharp`
- enry `c++` -> bblfsh `cpp`.

It still fails for
- enry `shell` -> bblfsh `bash`.

Unfortunately now that the tests parse the cpp and csharp files, they fail, so I had to disable them.
See https://github.com/bblfsh/cpp-driver/issues/31, https://github.com/bblfsh/bblfshd/issues/259