### PR TITLE
Add gitbase connection details to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,17 @@ srcd sql "SHOW tables;"
 **Note:**
 Engine's SQL supports a [UAST](#babelfish-uast) function that returns a Universal AST for the selected source text. UAST values are returned as binary blobs, and are best visualized in the `web sql` interface rather than the CLI where are seen as binary data.
 
+##### From Any MySQL Client
+
+You may also connect directly to gitbase using any MySQL compatible client. Use the login user **root**, no password, and database name **gitbase**.
+
+```bash
+# Start the component if needed
+srcd start srcd-cli-gitbase
+
+mysql --user=root --host=127.0.0.1 --port=3306 gitbase
+```
+
 #### Parsing Code
 
 Sometimes you may want to parse files directly as [UASTs](#babelfish-uast).


### PR DESCRIPTION
Fix #445, adding docs on how to connect to gitbase directly if you need to.

I used the `start` command from #433 even though it's not yet in master, because it should be before the next release.