### PR TITLE
Rename 'parse drivers list' sub command to 'parse drivers'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - `srcd` commands do not have a `-v/--verbose` flag anymore, it has been replaced with the `--log-level=debug` option ([#410](https://github.com/src-d/engine/issues/410)).
 - The `srcd/cli-daemon` docker image executable now requires to use the `serve` sub command. This does not affect end users ([#410](https://github.com/src-d/engine/issues/410)).
+- Command `srcd parse drivers list` has been renamed to `srcd parse drivers` ([#320](https://github.com/src-d/engine/issues/320)).
 
 ### New Features
 

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ srcd parse uast --lang=LANGUAGE /path/to/file
 To see the installed language drivers:
 
 ```bash
-srcd parse drivers list
+srcd parse drivers
 ```
 
 ### 5. Start Executing Queries

--- a/cmd/srcd/cmd/drivers.go
+++ b/cmd/srcd/cmd/drivers.go
@@ -9,12 +9,12 @@ import (
 	"github.com/src-d/engine/cmd/srcd/daemon"
 )
 
-// parseDriversListCmd represents the parse drivers list command
-type parseDriversListCmd struct {
-	Command `name:"list" short-description:"List installed language drivers" long-description:"List installed language drivers"`
+// parseDriverCmd represents the parse drivers command
+type parseDriverCmd struct {
+	Command `name:"drivers" short-description:"List installed language drivers" long-description:"List installed language drivers"`
 }
 
-func (cmd *parseDriversListCmd) Execute(args []string) error {
+func (cmd *parseDriverCmd) Execute(args []string) error {
 	c, err := daemon.Client()
 	if err != nil {
 		return humanizef(err, "could not get daemon client")

--- a/cmd/srcd/cmd/parse.go
+++ b/cmd/srcd/cmd/parse.go
@@ -173,18 +173,11 @@ func (cmd *parseLangCmd) Execute(args []string) error {
 	return nil
 }
 
-// parseDriversCmd represents the parse drivers command
-type parseDriversCmd struct {
-	cli.PlainCommand `name:"drivers" short-description:"Manage language drivers" long-description:"Manage language drivers"`
-}
-
 func init() {
 	c := rootCmd.AddCommand(&parseCmd{})
 	c.AddCommand(&parseUASTCmd{})
 	c.AddCommand(&parseLangCmd{})
-
-	driversCmd := c.AddCommand(&parseDriversCmd{})
-	driversCmd.AddCommand(&parseDriversListCmd{})
+	c.AddCommand(&parseDriverCmd{})
 }
 
 func parseModeArg(mode string) (api.ParseRequest_UastMode, error) {

--- a/cmdtests/parse_test.go
+++ b/cmdtests/parse_test.go
@@ -87,7 +87,7 @@ var testCases = []testCase{
 func (s *ParseTestSuite) TestDriversList() {
 	require := s.Require()
 
-	r := s.RunCommand("parse", "drivers", "list")
+	r := s.RunCommand("parse", "drivers")
 	require.NoError(r.Error, r.Combined())
 
 	/* Example output:

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -11,7 +11,6 @@ they've been implemented.
     - [srcd parse uast](#srcd-parse-uast)
     - [srcd parse lang](#srcd-parse-lang)
     - [srcd parse drivers](#srcd-parse-drivers)
-        - [srcd parse drivers list](#srcd-parse-drivers-list)
 - [srcd sql](#srcd-sql)
 - [srcd web](#srcd-web)
     - [srcd web parse](#srcd-web-parse)
@@ -111,10 +110,6 @@ Identifies the language of the given file.
 *flags*:
 
 ### srcd parse drivers
-All of the subcomands of `srcd parse drivers` provide management for
-the language drivers installed on `bblfsh`.
-
-#### srcd parse drivers list
 Lists all of the drivers already installed on `bblfsh` together with the
 version installed.
 


### PR DESCRIPTION
Fix #320.