### PR TITLE
Add cpu limits to gitbase container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,8 @@
   --log-force-format                     ignore if it is running on a terminal or not [$LOG_FORCE_FORMAT]
   ```
 
-  - New command `srcd components start component(s)`, to start source{d} components [#433](https://github.com/src-d/engine/issues/433)
+- New command `srcd components start component(s)`, to start source{d} components [#433](https://github.com/src-d/engine/issues/433)
+- The `gitbase` container can be very CPU intensive and some queries can cause the host to freeze. Now the container is started with a limit on the available host CPU ([#452](https://github.com/src-d/engine/issues/452)).
 
 ### Bug Fixes
 

--- a/cmd/srcd-server/engine/components.go
+++ b/cmd/srcd-server/engine/components.go
@@ -172,7 +172,7 @@ func (s *Server) gitbaseComponent(port int) (*Component, error) {
 
 	return &Component{
 		Name: gitbase.Name,
-		Start: createGitbase(
+		Start: s.createGitbase(
 			docker.WithROSharedDirectory(workdirHostPath, gitbaseMountPath, s.hostOS),
 			docker.WithVolume(indexVolumeName, gitbaseIndexMountPath, s.hostOS),
 			docker.WithPort(port, components.GitbasePort),

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -727,3 +727,18 @@ func resizeTty(c *client.Client, containerID string) error {
 		Width:  width,
 	})
 }
+
+// NCPU returns the number of CPUs in the docker host
+func NCPU(ctx context.Context) (int, error) {
+	c, err := GetClient()
+	if err != nil {
+		return 0, errors.Wrap(err, "could not create docker client")
+	}
+
+	info, err := c.Info(ctx)
+	if err != nil {
+		return 0, errors.Wrap(err, "could not get docker host info")
+	}
+
+	return info.NCPU, nil
+}


### PR DESCRIPTION
Fix #279.

Queries like `select * from files order by...` can freeze the system. It's happened to me a few times, and I've had to reboot my laptop. This PR adds a limit on the container access to the host CPU.

I chose a limit of 75% a bit arbitrarily. After playing around with a few values it seemed like the sweet spot.