### PR TITLE
fix integration tests build on windows

### DIFF
--- a/cmdtests/sql_interactive_test.go
+++ b/cmdtests/sql_interactive_test.go
@@ -1,0 +1,146 @@
+// +build integration,!windows
+
+package cmdtests_test
+
+import (
+	"fmt"
+	"io"
+	"os/exec"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/kr/pty"
+	"github.com/src-d/engine/cmdtests"
+	"github.com/src-d/engine/components"
+	"github.com/src-d/engine/docker"
+)
+
+func (s *SQLREPLTestSuite) TestInteractiveREPL() {
+	require := s.Require()
+
+	command, in, out, err := s.runInteractiveRepl()
+	require.NoError(err)
+
+	res := s.runInteractiveQuery(in, "show tables;\n", out)
+	require.Contains(res, showTablesOutput)
+
+	res = s.runInteractiveQuery(in, "describe table repositories;\n", out)
+	require.Contains(res, showRepoTableDescOutput)
+
+	require.NoError(s.exitInteractiveAndWait(10*time.Second, in, out))
+	require.NoError(s.waitMysqlCliContainerStopped(10, 1*time.Second))
+
+	command.Wait()
+}
+
+func (s *SQLREPLTestSuite) runInteractiveRepl() (*exec.Cmd, io.Writer, <-chan string, error) {
+	s.T().Helper()
+
+	// cannot use `icmd` here, please see: https://github.com/gotestyourself/gotest.tools/issues/151
+	command := exec.Command(s.Bin(), "sql")
+
+	ch := make(chan string)
+	cr := cmdtests.NewChannelWriter(ch)
+
+	command.Stdout = cr
+	command.Stderr = cr
+
+	in, err := pty.Start(command)
+	if err != nil {
+		panic(err)
+	}
+
+	linifier := cmdtests.NewStreamLinifier(1 * time.Second)
+	out := linifier.Linify(ch)
+	for s := range out {
+		if strings.HasPrefix(s, "mysql>") {
+			return command, in, out, nil
+		}
+	}
+
+	return nil, nil, nil, fmt.Errorf("Mysql cli prompt never started")
+}
+
+func (s *SQLREPLTestSuite) runInteractiveQuery(in io.Writer, query string, out <-chan string) string {
+	io.WriteString(in, query)
+
+	var res strings.Builder
+	for c := range out {
+		if strings.HasPrefix(c, "Empty set") {
+			return ""
+		}
+
+		res.WriteString(c + "\r\n")
+		if s.containsSQLOutput(res.String()) {
+			break
+		}
+	}
+
+	return res.String()
+}
+
+func (s *SQLREPLTestSuite) exitInteractiveAndWait(timeout time.Duration, in io.Writer, out <-chan string) error {
+	io.WriteString(in, "exit;\n")
+
+	done := make(chan struct{})
+	go func() {
+		for c := range out {
+			if strings.Contains(c, "Bye") {
+				done <- struct{}{}
+				// don't return in order to consume all output and let the process exit
+			}
+		}
+	}()
+
+	select {
+	case <-done:
+		return nil
+	case <-time.After(timeout):
+		return fmt.Errorf("timeout of %v elapsed while waiting to exit", timeout)
+	}
+}
+
+func (s *SQLREPLTestSuite) waitMysqlCliContainerStopped(retries int, retryTimeout time.Duration) error {
+	for i := 0; i < retries; i++ {
+		running, err := docker.IsRunning(components.MysqlCli.Name, "")
+		if !running {
+			return nil
+		}
+
+		if err != nil {
+			return err
+		}
+
+		time.Sleep(retryTimeout)
+	}
+
+	return fmt.Errorf("maximum number of retries (%d) reached while waiting to stop container", retries)
+}
+
+// containsSQLOutput returns `true` if the given string is a SQL output table.
+// To detect whether the `out` is a SQL output table, this checks that there
+// are exactly 3 separators matching this regex ``\+-+\+`.
+// In fact an example of SQL output is the following:
+//
+//     +--------------+  <-- first separator
+//     | Table        |
+//     +--------------+  <-- second separator
+//     | blobs        |
+//     | commit_blobs |
+//     | commit_files |
+//     | commit_trees |
+//     | commits      |
+//     | files        |
+//     | ref_commits  |
+//     | refs         |
+//     | remotes      |
+//     | repositories |
+//     | tree_entries |
+//     +--------------+  <-- third separator
+//
+func (s *SQLREPLTestSuite) containsSQLOutput(out string) bool {
+	sep := regexp.MustCompile(`\+-+\+`)
+	matches := sep.FindAllStringIndex(out, -1)
+	return len(matches) == 3
+}

--- a/cmdtests/sql_test.go
+++ b/cmdtests/sql_test.go
@@ -3,22 +3,14 @@
 package cmdtests_test
 
 import (
-	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"path"
 	"path/filepath"
-	"regexp"
-	"runtime"
 	"strings"
 	"testing"
-	"time"
 
-	"github.com/kr/pty"
 	"github.com/src-d/engine/cmdtests"
-	"github.com/src-d/engine/components"
-	"github.com/src-d/engine/docker"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -73,139 +65,6 @@ func (s *SQLREPLTestSuite) TestREPL() {
 	require.NoError(r.Error, r.Combined())
 	require.Contains(r.Combined(), showTablesOutput)
 	require.Contains(r.Combined(), showRepoTableDescOutput)
-}
-
-func (s *SQLREPLTestSuite) TestInteractiveREPL() {
-	if runtime.GOOS == "windows" {
-		s.T().Skip("Testing interactive REPL on Windows is not supported")
-	}
-
-	require := s.Require()
-
-	command, in, out, err := s.runInteractiveRepl()
-	require.NoError(err)
-
-	res := s.runInteractiveQuery(in, "show tables;\n", out)
-	require.Contains(res, showTablesOutput)
-
-	res = s.runInteractiveQuery(in, "describe table repositories;\n", out)
-	require.Contains(res, showRepoTableDescOutput)
-
-	require.NoError(s.exitInteractiveAndWait(10*time.Second, in, out))
-	require.NoError(s.waitMysqlCliContainerStopped(10, 1*time.Second))
-
-	command.Wait()
-}
-
-func (s *SQLREPLTestSuite) runInteractiveRepl() (*exec.Cmd, io.Writer, <-chan string, error) {
-	s.T().Helper()
-
-	// cannot use `icmd` here, please see: https://github.com/gotestyourself/gotest.tools/issues/151
-	command := exec.Command(s.Bin(), "sql")
-
-	ch := make(chan string)
-	cr := cmdtests.NewChannelWriter(ch)
-
-	command.Stdout = cr
-	command.Stderr = cr
-
-	in, err := pty.Start(command)
-	if err != nil {
-		panic(err)
-	}
-
-	linifier := cmdtests.NewStreamLinifier(1 * time.Second)
-	out := linifier.Linify(ch)
-	for s := range out {
-		if strings.HasPrefix(s, "mysql>") {
-			return command, in, out, nil
-		}
-	}
-
-	return nil, nil, nil, fmt.Errorf("Mysql cli prompt never started")
-}
-
-func (s *SQLREPLTestSuite) runInteractiveQuery(in io.Writer, query string, out <-chan string) string {
-	io.WriteString(in, query)
-
-	var res strings.Builder
-	for c := range out {
-		if strings.HasPrefix(c, "Empty set") {
-			return ""
-		}
-
-		res.WriteString(c + "\r\n")
-		if s.containsSQLOutput(res.String()) {
-			break
-		}
-	}
-
-	return res.String()
-}
-
-func (s *SQLREPLTestSuite) exitInteractiveAndWait(timeout time.Duration, in io.Writer, out <-chan string) error {
-	io.WriteString(in, "exit;\n")
-
-	done := make(chan struct{})
-	go func() {
-		for c := range out {
-			if strings.Contains(c, "Bye") {
-				done <- struct{}{}
-				// don't return in order to consume all output and let the process exit
-			}
-		}
-	}()
-
-	select {
-	case <-done:
-		return nil
-	case <-time.After(timeout):
-		return fmt.Errorf("timeout of %v elapsed while waiting to exit", timeout)
-	}
-}
-
-func (s *SQLREPLTestSuite) waitMysqlCliContainerStopped(retries int, retryTimeout time.Duration) error {
-	for i := 0; i < retries; i++ {
-		running, err := docker.IsRunning(components.MysqlCli.Name, "")
-		if !running {
-			return nil
-		}
-
-		if err != nil {
-			return err
-		}
-
-		time.Sleep(retryTimeout)
-	}
-
-	return fmt.Errorf("maximum number of retries (%d) reached while waiting to stop container", retries)
-}
-
-// containsSQLOutput returns `true` if the given string is a SQL output table.
-// To detect whether the `out` is a SQL output table, this checks that there
-// are exactly 3 separators matching this regex ``\+-+\+`.
-// In fact an example of SQL output is the following:
-//
-//     +--------------+  <-- first separator
-//     | Table        |
-//     +--------------+  <-- second separator
-//     | blobs        |
-//     | commit_blobs |
-//     | commit_files |
-//     | commit_trees |
-//     | commits      |
-//     | files        |
-//     | ref_commits  |
-//     | refs         |
-//     | remotes      |
-//     | repositories |
-//     | tree_entries |
-//     +--------------+  <-- third separator
-//
-func (s *SQLREPLTestSuite) containsSQLOutput(out string) bool {
-	sep := regexp.MustCompile(`\+-+\+`)
-	matches := sep.FindAllStringIndex(out, -1)
-	return len(matches) == 3
 }
 
 type SQLTestSuite struct {


### PR DESCRIPTION
pty.Start isn't exported on windows which fails build.

I moved interactive repl test into separate file with !windows build tag

Signed-off-by: Maxim Sukharev <max@smacker.ru>