### PR TITLE
Fix flaky `StreamLinifierTestSuite/TestSlowPendingMessage` test

### DIFF
--- a/cmdtests/common_test.go
+++ b/cmdtests/common_test.go
@@ -93,7 +93,7 @@ func (s *StreamLinifierTestSuite) TestMultiLinesOnOneMessage() {
 func (s *StreamLinifierTestSuite) TestSlowPendingMessage() {
 	require := s.Require()
 
-	sl := cmdtests.NewStreamLinifier(1 * time.Second)
+	sl := cmdtests.NewStreamLinifier(500 * time.Millisecond)
 
 	in := make(chan string)
 


### PR DESCRIPTION
The timeout for pending messages in the test
`StreamLinifierTestSuite/TestSlowPendingMessage` is incorrect. This test
is supposed to test that slow messages are considered as part
of different lines, but the timeout value being used is the same of
the time that passes between each message. This leads to a
non-deterministic output. This is fixed by decreasing the timeout the
`StreamLinifier` is configured with.

Signed-off-by: Lou Marvin Caraig <loumarvincaraig@gmail.com>