### PR TITLE
Bump gopkg.in/src-d/go-log.v1 to v1.0.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	gopkg.in/src-d/enry.v1 v1.7.3
 	gopkg.in/src-d/go-cli.v0 v0.0.0-20190422143124-3a646154da79
 	gopkg.in/src-d/go-git.v4 v4.10.0 // indirect
-	gopkg.in/src-d/go-log.v1 v1.0.1
+	gopkg.in/src-d/go-log.v1 v1.0.2
 	gopkg.in/src-d/regression-core.v0 v0.0.0-20190403084152-bacbc259429b
 	gopkg.in/toqueteos/substring.v1 v1.0.2 // indirect
 	gopkg.in/yaml.v2 v2.2.2

--- a/go.sum
+++ b/go.sum
@@ -231,8 +231,8 @@ gopkg.in/src-d/go-git-fixtures.v3 v3.1.1 h1:XWW/s5W18RaJpmo1l0IYGqXKuJITWRFuA45i
 gopkg.in/src-d/go-git-fixtures.v3 v3.1.1/go.mod h1:dLBcvytrw/TYZsNTWCnkNF2DSIlzWYqTe3rJR56Ac7g=
 gopkg.in/src-d/go-git.v4 v4.10.0 h1:NWjTJTQnk8UpIGlssuefyDZ6JruEjo5s88vm88uASbw=
 gopkg.in/src-d/go-git.v4 v4.10.0/go.mod h1:Vtut8izDyrM8BUVQnzJ+YvmNcem2J89EmfZYCkLokZk=
-gopkg.in/src-d/go-log.v1 v1.0.1 h1:heWvX7J6qbGWbeFS/aRmiy1eYaT+QMV6wNvHDyMjQV4=
-gopkg.in/src-d/go-log.v1 v1.0.1/go.mod h1:GN34hKP0g305ysm2/hctJ0Y8nWP3zxXXJ8GFabTyABE=
+gopkg.in/src-d/go-log.v1 v1.0.2 h1:dED4100pntH4l3qOTgD1xebQR6pVU8tuPbUCmqiMsb0=
+gopkg.in/src-d/go-log.v1 v1.0.2/go.mod h1:GN34hKP0g305ysm2/hctJ0Y8nWP3zxXXJ8GFabTyABE=
 gopkg.in/src-d/regression-core.v0 v0.0.0-20190403084152-bacbc259429b h1:0iZM2DkVH5lzZpfarhmZGCvgQwPjl4k66ufikIPHWiU=
 gopkg.in/src-d/regression-core.v0 v0.0.0-20190403084152-bacbc259429b/go.mod h1:mMBM8dkdhWi1uUf+wv40Zbn3ZhKaDgHsa0V66HOXnTE=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=

--- a/vendor/gopkg.in/src-d/go-log.v1/MAINTAINERS
+++ b/vendor/gopkg.in/src-d/go-log.v1/MAINTAINERS
@@ -1,0 +1,1 @@
+Máximo Cuadros <mcuadros@gmail.com> (@mcuadros)

--- a/vendor/gopkg.in/src-d/go-log.v1/README.md
+++ b/vendor/gopkg.in/src-d/go-log.v1/README.md
@@ -21,8 +21,8 @@ The configuration should be done always using environment variables. The list
 of available variables is:
 
 - `LOG_LEVEL`: Reporting level, values are "info", "debug", "warning" or "error".
-- `LOG_FORMAT`: Format of the log lines, values are "text" or "json", by default "text" is used. unless a terminal can't be detected, in this case, "json" is used instead.
-- `LOG_FIELDS`: Fields in JSON format to be included in all the loggers.
+- `LOG_FORMAT`: Format of the log lines, values are "text", "json" or "fluentd", by default "text" is used. unless a terminal can't be detected, in this case, "json" is used instead.
+- `LOG_FIELDS`: Fields in JSON or fluentd format to be included in all the loggers.
 - `LOG_FORCE_FORMAT`: If true the fact of being in a terminal or not is ignored.
 
 > By default the logging is disabled if go-log is being executed in tests.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -307,7 +307,7 @@ gopkg.in/src-d/go-git.v4/storage/filesystem/dotgit
 gopkg.in/src-d/go-git.v4/utils/merkletrie/internal/frame
 gopkg.in/src-d/go-git.v4/plumbing/transport/internal/common
 gopkg.in/src-d/go-git.v4/plumbing/transport/server
-# gopkg.in/src-d/go-log.v1 v1.0.1
+# gopkg.in/src-d/go-log.v1 v1.0.2
 gopkg.in/src-d/go-log.v1
 # gopkg.in/src-d/regression-core.v0 v0.0.0-20190403084152-bacbc259429b
 gopkg.in/src-d/regression-core.v0


### PR DESCRIPTION
Part of #456.
Includes the fix for wrong log color characters in windows.