### PR TITLE
Download compose files using the build version

### DIFF
--- a/cmd/sourced/cmd/compose.go
+++ b/cmd/sourced/cmd/compose.go
@@ -13,7 +13,7 @@ type composeCmd struct {
 }
 
 type composeDownloadCmd struct {
-	Command `name:"download" short-description:"Download docker compose files" long-description:"Download docker compose files. By default the command downloads the file in master.\n\nUse the 'version' argument to choose a specific revision from\nthe https://github.com/src-d/sourced-ce repository, or to set a\nURL to a docker-compose.yml file.\n\nExamples:\n\nsourced compose download\nsourced compose download v0.0.1\nsourced compose download master\nsourced compose download https://raw.githubusercontent.com/src-d/sourced-ce/master/docker-compose.yml"`
+	Command `name:"download" short-description:"Download docker compose files" long-description:"Download docker compose files. By default the command downloads the file for this binary version.\n\nUse the 'version' argument to choose a specific revision from\nthe https://github.com/src-d/sourced-ce repository, or to set a\nURL to a docker-compose.yml file.\n\nExamples:\n\nsourced compose download\nsourced compose download v0.0.1\nsourced compose download master\nsourced compose download https://raw.githubusercontent.com/src-d/sourced-ce/master/docker-compose.yml"`
 
 	Args struct {
 		Version string `positional-arg-name:"version" description:"Either a revision (tag, full sha1) or a URL to a docker-compose.yml file"`
@@ -23,7 +23,7 @@ type composeDownloadCmd struct {
 func (c *composeDownloadCmd) Execute(args []string) error {
 	v := c.Args.Version
 	if v == "" {
-		v = "master"
+		v = version
 	}
 
 	err := composefile.Download(v)

--- a/cmd/sourced/cmd/root.go
+++ b/cmd/sourced/cmd/root.go
@@ -8,6 +8,13 @@ const name = "sourced"
 
 var rootCmd = cli.NewNoDefaults(name, "source{d} CE and EE installer")
 
+var version = "master"
+
+// SetVersion sets the version rewritten by the CI build
+func SetVersion(v string) {
+	version = v
+}
+
 // Command implements the default group flags. It is meant to be embedded into
 // other application commands to provide default behavior for logging, config
 type Command struct {

--- a/cmd/sourced/compose/file/file.go
+++ b/cmd/sourced/compose/file/file.go
@@ -21,6 +21,8 @@ const (
 	composeFileTmpl = "https://raw.githubusercontent.com/%s/%s/%s/docker-compose.yml"
 )
 
+var version = "master"
+
 // activeDir is the name of the directory containing the symlink to the
 // active docker compose file
 const activeDir = "__active__"
@@ -35,8 +37,15 @@ func composeFileURL(revision string) string {
 	return fmt.Sprintf(composeFileTmpl, orgName, repoName, revision)
 }
 
-// InitDefault downloads the master docker-compose.yml only if it does not
-// exist. It returns the absolute path to the active docker-compose.yml file
+// SetVersion sets the version rewritten by the CI build
+func SetVersion(v string) {
+	version = v
+}
+
+// InitDefault checks if there is an active docker compose file, and if there
+// isn't the file for this release is downloaded.
+// The current build version must be set with SetVersion.
+// It returns the absolute path to the active docker-compose.yml file
 func InitDefault() (string, error) {
 	activeFilePath, err := path(activeDir)
 	if err != nil {
@@ -52,9 +61,9 @@ func InitDefault() (string, error) {
 		return "", err
 	}
 
-	err = Download("master")
+	err = Download(version)
 	if err != nil {
-		return "", nil
+		return "", err
 	}
 
 	return activeFilePath, nil

--- a/cmd/sourced/main.go
+++ b/cmd/sourced/main.go
@@ -2,8 +2,15 @@ package main
 
 import (
 	"github.com/src-d/sourced-ce/cmd/sourced/cmd"
+	composefile "github.com/src-d/sourced-ce/cmd/sourced/compose/file"
 )
 
+// this variable is rewritten during the CI build step
+var version = "master"
+
 func main() {
+	composefile.SetVersion(version)
+	cmd.SetVersion(version)
+
 	cmd.Execute()
 }


### PR DESCRIPTION
Fix #1.

For `go run` the tool will download from `master`, and for a released binary it will download the file from github, at the version tag.

I thought about downloading from the release assets, `https://github.com/src-d/sourced-ce/releases/download/ <<version>> /docker-compose.yml`, but right now the tool creates nicer and shorter names for git versions compared to URLs.

```
  https://github.com/src-d/sourced-ce/releases/download/v0.14.0-beta.1/docker-compose.yml
* v0.14.0-beta.1
```