### PR TITLE
Rename 'install' command as 'init'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Initial release. It includes a `docker-compose.yml` file to deploy source{d} CE 
 
 The `sourced` binary is a wrapper for Docker Compose that downloads the `docker-compose.yml` file from this repository, and includes the following sub commands:
 
-- `install`: Install and initialize containers
+- `init`: Install and initialize containers
 - `status`: Shows status of the components
 - `stop`: Stop running containers
 - `start`: Start stopped containers

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ You may also choose to manage the containers yourself with the `docker-compose.y
 
 ### Commands
 
-#### Install
+#### Init
 
 ```
-sourced install /path/to/repositories
+sourced init /path/to/repositories
 ```
 
 This will initialize **source{d} CE** to analyze the given Git repositories.
@@ -43,7 +43,7 @@ If the UI wasn't opened automatically, use `sourced web` or visit http://localho
 sourced start
 ```
 
-This will start all the components previously initialized with `install`.
+This will start all the components previously initialized with `init`.
 
 #### Stop
 
@@ -59,7 +59,7 @@ This will stop all running containers without removing them. They can be started
 sourced prune
 ```
 
-Stops containers and removes containers, networks, and volumes created by `install`.
+Stops containers and removes containers, networks, and volumes created by `init`.
 Images are not deleted unless you specify the `--images` flag.
 
 If you want to completely uninstall `sourced` you may want to delete the `~/.srcd` directory.
@@ -123,12 +123,12 @@ You can deploy more than one **source{d} CE** instance with different sets of re
 
 For example you may have initially started **source{d} CE** with the repositories in `~/repos`, with the command:
 ```
-sourced install ~/repos
+sourced init ~/repos
 ```
 
-After a while you may want to analyze the data on another set of repositories. You can run `install` again with a different path:
+After a while you may want to analyze the data on another set of repositories. You can run `init` again with a different path:
 ```
-sourced install ~/go/src/github.com/src-d
+sourced init ~/go/src/github.com/src-d
 ```
 
 This command will stop any of the currently running containers, create an isolated environment for the new repositories path, and create a new, clean deployment.
@@ -137,12 +137,12 @@ Please note that each path will have an isolated deployment. This means that for
 
 Each isolated environment is persistent (unless you run `prune`). Which means that if you decide to re-deploy **source{d} CE** using the original set of repositories:
 ```
-sourced install ~/repos
+sourced init ~/repos
 ```
 
 You will get back to the previous state, and things like charts and dashboards will be restored.
 
-If you are familiar with Docker Compose and you want more control over the underlying resources, you can explore the contents of your `~/.srcd` directory. There you will find a `docker-compose.yml` and `.env` files for each set of repositories used by `sourced install`.
+If you are familiar with Docker Compose and you want more control over the underlying resources, you can explore the contents of your `~/.srcd` directory. There you will find a `docker-compose.yml` and `.env` files for each set of repositories used by `sourced init`.
 
 ## Docker Compose
 

--- a/cmd/sourced/cmd/init.go
+++ b/cmd/sourced/cmd/init.go
@@ -14,15 +14,15 @@ import (
 	"github.com/pkg/errors"
 )
 
-type installCmd struct {
-	Command `name:"install" short-description:"Install and initialize containers" long-description:"Install, initialize, and start all the required docker containers, networks, volumes, and images.\n\nThe repos directory argument must point to a directory containing git repositories.\nIf it's not provided, the current working directory will be used."`
+type initCmd struct {
+	Command `name:"init" short-description:"Install and initialize containers" long-description:"Install, initialize, and start all the required docker containers, networks, volumes, and images.\n\nThe repos directory argument must point to a directory containing git repositories.\nIf it's not provided, the current working directory will be used."`
 
 	Args struct {
 		Reposdir string `positional-arg-name:"workdir"`
 	} `positional-args:"yes"`
 }
 
-func (c *installCmd) Execute(args []string) error {
+func (c *initCmd) Execute(args []string) error {
 	reposdir, err := c.reposdirArg()
 	if err != nil {
 		return err
@@ -50,7 +50,7 @@ func (c *installCmd) Execute(args []string) error {
 	return OpenUI(time.Minute)
 }
 
-func (c *installCmd) reposdirArg() (string, error) {
+func (c *initCmd) reposdirArg() (string, error) {
 	reposdir := c.Args.Reposdir
 	reposdir = strings.TrimSpace(reposdir)
 
@@ -74,5 +74,5 @@ func (c *installCmd) reposdirArg() (string, error) {
 }
 
 func init() {
-	rootCmd.AddCommand(&installCmd{})
+	rootCmd.AddCommand(&initCmd{})
 }

--- a/cmd/sourced/cmd/prune.go
+++ b/cmd/sourced/cmd/prune.go
@@ -7,7 +7,7 @@ import (
 )
 
 type pruneCmd struct {
-	Command `name:"prune" short-description:"Stop and remove containers and resources" long-description:"Stops containers and removes containers, networks, and volumes created by 'install'.\nImages are not deleted unless you specify the --images flag."`
+	Command `name:"prune" short-description:"Stop and remove containers and resources" long-description:"Stops containers and removes containers, networks, and volumes created by 'init'.\nImages are not deleted unless you specify the --images flag."`
 
 	Images bool `long:"images" description:"Remove docker images"`
 }

--- a/cmd/sourced/cmd/start.go
+++ b/cmd/sourced/cmd/start.go
@@ -8,7 +8,7 @@ import (
 )
 
 type startCmd struct {
-	Command `name:"start" short-description:"Start stopped containers" long-description:"Start stopped containers.\nThe containers must be initialized before with 'install'."`
+	Command `name:"start" short-description:"Start stopped containers" long-description:"Start stopped containers.\nThe containers must be initialized before with 'init'."`
 }
 
 func (c *startCmd) Execute(args []string) error {


### PR DESCRIPTION
fix #11

After #2, the `install` subcommand is not only used for the first time you run source{d}, but also to come back to a dir that was used previously.

As described in #11 I choose `init`, but I'm opened to suggestions.