### PR TITLE
Remove active workdir on prune

### DIFF
--- a/cmd/sourced/cmd/workdirs.go
+++ b/cmd/sourced/cmd/workdirs.go
@@ -16,11 +16,8 @@ func (c *workdirsCmd) Execute(args []string) error {
 		return err
 	}
 
-	active, err := workdir.ActiveRepoDir()
-	if err != nil {
-		return err
-	}
-
+	// ignore errors if active dir doesn't exist or unavailable
+	active, _ := workdir.ActiveRepoDir()
 	for _, dir := range dirs {
 		if dir == active {
 			fmt.Printf("* %s\n", dir)


### PR DESCRIPTION
Fix: #33

After prune any command will fail with
```
lstat $HOME/.srcd/workdirs/__active__: no such file or directory
```
and requires running init again. The issue is already tracked in #12.

Signed-off-by: Maxim Sukharev <max@smacker.ru>