### PR TITLE
Delete symlink and active workdir on prune

### DIFF
--- a/cmd/sourced/cmd/prune.go
+++ b/cmd/sourced/cmd/prune.go
@@ -47,7 +47,7 @@ func (c *pruneCmd) pruneActive() error {
 		return err
 	}
 
-	dir, err := workdir.Active()
+	dir, err := workdir.EvalActive()
 	if err != nil {
 		return err
 	}

--- a/cmd/sourced/compose/workdir/workdir.go
+++ b/cmd/sourced/compose/workdir/workdir.go
@@ -134,7 +134,7 @@ func UnsetActive() error {
 		return err
 	}
 
-	_, err = os.Stat(dir)
+	_, err = os.Lstat(dir)
 	if !os.IsNotExist(err) {
 		err = os.Remove(dir)
 		if err != nil {


### PR DESCRIPTION
caused by https://github.com/src-d/sourced-ce/pull/38

`prune` command was deleting `.env`, `docker-compose.yml` and `__active__` symlink,
but not the active workdir itself.

UnsetActive must work with Lstat to check symlink status, instead of accessing the pointed dir.
Prune command must use the real workdir path, instead of the symlink route.