### PR TITLE
Rename .srcd as .sourced

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ sourced prune
 Stops containers and removes containers, networks, and volumes created by `init`.
 Images are not deleted unless you specify the `--images` flag.
 
-If you want to completely uninstall `sourced` you may want to delete the `~/.srcd` directory.
+If you want to completely uninstall `sourced` you may want to delete the `~/.sourced` directory.
 
 #### Status
 
@@ -141,7 +141,7 @@ Lists previously initialized working directories.
 sourced compose
 ```
 
-Manage docker compose files in the `~/.srcd` directory with the following sub commands:
+Manage docker compose files in the `~/.sourced` directory with the following sub commands:
 
 ##### Download
 
@@ -197,7 +197,7 @@ sourced init ~/repos
 
 You will get back to the previous state, and things like charts and dashboards will be restored.
 
-If you are familiar with Docker Compose and you want more control over the underlying resources, you can explore the contents of your `~/.srcd` directory. There you will find a `docker-compose.yml` and `.env` files for each set of repositories used by `sourced init`.
+If you are familiar with Docker Compose and you want more control over the underlying resources, you can explore the contents of your `~/.sourced` directory. There you will find a `docker-compose.yml` and `.env` files for each set of repositories used by `sourced init`.
 
 ## Docker Compose
 

--- a/cmd/sourced/cmd/compose.go
+++ b/cmd/sourced/cmd/compose.go
@@ -31,7 +31,7 @@ func (c *composeDownloadCmd) Execute(args []string) error {
 		return err
 	}
 
-	fmt.Println("Docker compose file successfully downloaded to your ~/.srcd/compose-files directory. It is now the active compose file.")
+	fmt.Println("Docker compose file successfully downloaded to your ~/.sourced/compose-files directory. It is now the active compose file.")
 	return nil
 }
 

--- a/cmd/sourced/compose/file/file.go
+++ b/cmd/sourced/compose/file/file.go
@@ -1,5 +1,5 @@
 // Package file provides functions to manage docker compose files inside the
-// $HOME/.srcd/compose-files directory
+// $HOME/.sourced/compose-files directory
 package file
 
 import (
@@ -93,7 +93,7 @@ func Download(revOrURL RevOrURL) error {
 }
 
 // SetActive makes a symlink from
-// $HOME/.srcd/compose-files/__active__/docker-compose.yml to the compose file
+// $HOME/.sourced/compose-files/__active__/docker-compose.yml to the compose file
 // for the given revision or URL.
 func SetActive(revOrURL RevOrURL) error {
 	filePath, err := path(revOrURL)
@@ -200,7 +200,7 @@ func isURL(revOrURL RevOrURL) bool {
 	return err == nil
 }
 
-// dir returns the absolute path for $HOME/.srcd/compose-files
+// dir returns the absolute path for $HOME/.sourced/compose-files
 func dir() (string, error) {
 	path, err := datadir.Path()
 	if err != nil {
@@ -211,7 +211,7 @@ func dir() (string, error) {
 }
 
 // path returns the absolute path to
-// $HOME/.srcd/compose-files/revOrURL/docker-compose.yml
+// $HOME/.sourced/compose-files/revOrURL/docker-compose.yml
 func path(revOrURL RevOrURL) (string, error) {
 	composeDirPath, err := dir()
 	if err != nil {

--- a/cmd/sourced/compose/workdir/workdir.go
+++ b/cmd/sourced/compose/workdir/workdir.go
@@ -1,5 +1,5 @@
 // Package workdir provides functions to manage docker compose working
-// directories inside the $HOME/.srcd/workdirs directory
+// directories inside the $HOME/.sourced/workdirs directory
 package workdir
 
 import (
@@ -23,11 +23,11 @@ const activeDir = "__active__"
 // RequiredFiles list of required files in a directory to treat it as a working directory
 var RequiredFiles = []string{".env", "docker-compose.yml"}
 
-// Init creates a working directory in ~/.srcd for the given repositories
+// Init creates a working directory in ~/.sourced for the given repositories
 // directory. The working directory will contain a docker-compose.yml and a
 // .env file.
 // If the directory is already initialized the function returns with no error.
-// The returned value is the absolute path to $HOME/.srcd/workdirs/reposdir
+// The returned value is the absolute path to $HOME/.sourced/workdirs/reposdir
 func Init(reposdir string) (string, error) {
 	defaultFilePath, err := composefile.InitDefault()
 	if err != nil {
@@ -145,12 +145,12 @@ func UnsetActive() error {
 	return nil
 }
 
-// Active returns the absolute path to $HOME/.srcd/workdirs/__active__
+// Active returns the absolute path to $HOME/.sourced/workdirs/__active__
 func Active() (string, error) {
 	return path(activeDir)
 }
 
-// EvalActive returns resolved path to $HOME/.srcd/workdirs/__active__
+// EvalActive returns resolved path to $HOME/.sourced/workdirs/__active__
 func EvalActive() (string, error) {
 	active, err := Active()
 	if err != nil {
@@ -238,7 +238,7 @@ func ListRepoDirs() ([]string, error) {
 }
 
 // path returns the absolute path to
-// $HOME/.srcd/workdirs/reposdir
+// $HOME/.sourced/workdirs/reposdir
 func path(reposdir string) (string, error) {
 	path, err := workdirsPath()
 	if err != nil {

--- a/cmd/sourced/dir/dir.go
+++ b/cmd/sourced/dir/dir.go
@@ -1,4 +1,4 @@
-// Package dir provides functions to manage the $HOME/.srcd and /tmp/srcd
+// Package dir provides functions to manage the $HOME/.sourced and /tmp/srcd
 // directories
 package dir
 
@@ -12,14 +12,14 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Path returns the absolute path for $HOME/.srcd
+// Path returns the absolute path for $HOME/.sourced
 func Path() (string, error) {
 	homedir, err := os.UserHomeDir()
 	if err != nil {
 		return "", errors.Wrap(err, "could not detect home directory")
 	}
 
-	return filepath.Join(homedir, ".srcd"), nil
+	return filepath.Join(homedir, ".sourced"), nil
 }
 
 // DownloadURL downloads the given url to a file to the


### PR DESCRIPTION
fix #36

If the users already have `.srcd` they should delete it.
If they want to migrate it, they must:
- rename it as `.sourced`
- recreate `__active__` and `docker-compose.yml` symlinks

