### PR TITLE
Increase timeout for init to 1 hour

### DIFF
--- a/cmd/sourced/cmd/init.go
+++ b/cmd/sourced/cmd/init.go
@@ -47,7 +47,7 @@ func (c *initCmd) Execute(args []string) error {
 		return err
 	}
 
-	return OpenUI(time.Minute)
+	return OpenUI(60 * time.Minute)
 }
 
 func (c *initCmd) reposdirArg() (string, error) {


### PR DESCRIPTION
The performance of init command depends on hardware.
Better add some really big timeout (1 hour) than exiting while
everything is actually starting.

On my laptop with ghcollector init takes almost 5 minutes already.

Signed-off-by: Maxim Sukharev <max@smacker.ru>