### PR TITLE
Upgrade gitbase to v0.21.0-beta1 (from v0.20.0)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     restart: always
 
   gitbase:
-    image: srcd/gitbase:v0.20.0
+    image: srcd/gitbase:v0.21.0-beta1
     ports:
       - 3306:3306
     environment:


### PR DESCRIPTION
fix #46

I tried source{d} with:
- a new `gitbase:v0.21.0-beta1`
- a new image of `sourced-ui`, locally built from `cc81a13` (after [#110](https://github.com/src-d/sourced-ui/pull/110), with new dashboards)

The welcome dashboard looks the same with the newer version of `gitbase` and the prev one `v0.20.0`