### PR TITLE
Implement token and orgs validation 

### DIFF
--- a/cmd/sourced/cmd/orgs.go
+++ b/cmd/sourced/cmd/orgs.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -40,6 +41,19 @@ func (c *orgsInitCmd) Execute(args []string) error {
 	}
 
 	fmt.Printf("docker-compose working directory set to %s\n", strings.Join(c.Args.Orgs, ","))
+
+	err = compose.Run(context.Background(), "run",
+		// have to override endpoint:
+		// $ docker-compose run --rm --no-deps ghsync validate
+		// /bin/sh: can't open 'validate': No such file or directory
+		// $ docker-compose run --rm --no-deps --entrypoint /bin/ghsync ghsync validate
+		// github token is not valid
+		"--entrypoint", "/bin/ghsync",
+		"--rm", "--no-deps", "ghsync", "validate")
+	if err != nil {
+		// avoid duplicated "exit status 1" message
+		os.Exit(1)
+	}
 
 	if err := compose.Run(context.Background(), "up", "--detach"); err != nil {
 		return err

--- a/cmd/sourced/compose/workdir/common.go
+++ b/cmd/sourced/compose/workdir/common.go
@@ -47,7 +47,7 @@ func (f *envFile) String() string {
 	GITBASE_VOLUME_TYPE=%s
 	GITBASE_VOLUME_SOURCE=%s
 	GITBASE_SIVA=%s
-	GITHUB_ORGANIZATION=%s
+	GITHUB_ORGANIZATIONS=%s
 	GITHUB_TOKEN=%s
 	`, f.Workdir, volumeType, volumeSource, gitbaseSiva,
 		strings.Join(f.GithubOrganizations, ","), f.GithubToken)

--- a/cmd/sourced/compose/workdir/org.go
+++ b/cmd/sourced/compose/workdir/org.go
@@ -2,11 +2,15 @@ package workdir
 
 import (
 	"encoding/base64"
+	"sort"
 	"strings"
 )
 
 // InitWithOrgs initialize workdir with remote list of organizations
 func InitWithOrgs(orgs []string, token string) (string, error) {
+	// be indifferent to the order of passed organizations
+	sort.Strings(orgs)
+
 	workdir := base64.StdEncoding.EncodeToString([]byte(strings.Join(orgs, ",")))
 	workdirPath, err := absolutePath(workdir)
 	if err != nil {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,11 +8,11 @@ services:
     restart: always
 
   gitcollector:
-    image: srcd/gitcollector:v0.0.1-beta.3
+    image: srcd/gitcollector:v0.0.1-beta.5
     # wait for db
     command: ['/bin/sh', '-c', 'sleep 10s && gitcollector download']
     environment:
-      GITHUB_ORGANIZATION: ${GITHUB_ORGANIZATION:-}
+      GITHUB_ORGANIZATIONS: ${GITHUB_ORGANIZATIONS:-}
       GITHUB_TOKEN: ${GITHUB_TOKEN:-}
       # use main db
       GITCOLLECTOR_METRICS_DB_URI: postgresql://superset:superset@postgres:5432/superset?sslmode=disable
@@ -26,7 +26,8 @@ services:
         consistency: delegated
 
   ghsync:
-    image: srcd/ghsync:v0.1.0
+    # FIXME use real release when it is published
+    image: srcd/ghsync:v0.1.0-multi
     entrypoint: ['/bin/sh']
     # wait for db to be created
     # we need to use something like https://github.com/vishnubob/wait-for-it
@@ -35,7 +36,7 @@ services:
     depends_on:
       - metadatadb
     environment:
-      GHSYNC_ORG: ${GITHUB_ORGANIZATION:-}
+      GHSYNC_ORGS: ${GITHUB_ORGANIZATIONS:-}
       GHSYNC_TOKEN: ${GITHUB_TOKEN:-}
       GHSYNC_POSTGRES_DB: metadata
       GHSYNC_POSTGRES_USER: metadata
@@ -45,7 +46,7 @@ services:
 
   gitbase:
     #image: srcd/gitbase:v0.21.0-beta1
-    image: jfontan/gitbase:siva-2
+    image: jfontan/gitbase:siva-4
     ports:
       - 3306:3306
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
 
   ghsync:
     # FIXME use real release when it is published
-    image: srcd/ghsync:v0.1.0-multi
+    image: srcd/ghsync:v0.1.0-validate
     entrypoint: ['/bin/sh']
     # wait for db to be created
     # we need to use something like https://github.com/vishnubob/wait-for-it


### PR DESCRIPTION
Fix: #59
Based on: #63
Only the [last commit](https://github.com/src-d/sourced-ce/commit/8db677d5121e6c0579e972eab64d77aa761ef9a5) is new.

This PR fixes the issue according to the agreement but I have doubts it's the best way to validate stuff.

Current problems:
- workdir get created before validation
- even with `--no-deps` docker-compose already creates network and volume
- in case of wrong organization there will be workdir with this wrong org
- we can't prune automatically on error because init can be actually "re-init" and prune would delete everything

I would better re-work it using simple http requests to github in the cli itself before starting messing with docker-compose. Or use docker instead of docker-compose. WDYT?