### PR TITLE
Remove ability to pass through vars

### DIFF
--- a/cmd/sourced/compose/compose.go
+++ b/cmd/sourced/compose/compose.go
@@ -21,7 +21,6 @@ import (
 const dockerComposeVersion = "1.24.0"
 
 var composeContainerURL = fmt.Sprintf("https://github.com/docker/compose/releases/download/%s/run.sh", dockerComposeVersion)
-var envKeys = []string{"GITBASE_REPOS_DIR"}
 
 type Compose struct {
 	bin string
@@ -45,19 +44,6 @@ func (c *Compose) RunWithIO(ctx context.Context, stdin io.Reader,
 	}
 
 	cmd.Dir = dir
-
-	var compOpts []string
-	for _, key := range envKeys {
-		val, ok := os.LookupEnv(key)
-		if !ok {
-			continue
-		}
-
-		compOpts = append(compOpts, fmt.Sprintf("-e %s=%s", key, val))
-	}
-
-	cmd.Env = append(os.Environ(),
-		fmt.Sprintf("COMPOSE_OPTIONS=%s", strings.Join(compOpts, " ")))
 	cmd.Stdin = stdin
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr


### PR DESCRIPTION
Fix: #58

The reasons:
- The env var was renamed in one of the PRs already
- .env file grows. Allowing a user changing it from outside can break things.
- A user can be not aware of set variables in his environment but they will
override values from .env which would cause very strange bug reports.

Signed-off-by: Maxim Sukharev <max@smacker.ru>