### PR TITLE
Do not upload docker-compose.yml to GitHub release assets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,6 @@ jobs:
         file_glob: true
         file:
           - build/*.tar.gz
-          - docker-compose.yml
         skip_cleanup: true
         on:
           all_branches: true


### PR DESCRIPTION
Having the docker-compose file in the release assets has been reported by users to be confusing.

At some point it was defined that we would release `sourced` and `docker-compose.yml` files independently.
But as things are right now, each release is a `sourced` binary that downloads the exact compose version for its build version. The download url is built from the repository, not the releases page.