### PR TITLE
Add restart subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,5 +25,6 @@ The `sourced` binary is a wrapper for Docker Compose that downloads the `docker-
   - `download`: Download docker compose files
   - `list`: List the downloaded docker compose files
   - `set`: Set the active docker compose file
+- `restart`: Update current installation according to the active docker compose file
 
 </details>

--- a/cmd/sourced/cmd/compose.go
+++ b/cmd/sourced/cmd/compose.go
@@ -32,6 +32,7 @@ func (c *composeDownloadCmd) Execute(args []string) error {
 	}
 
 	fmt.Println("Docker compose file successfully downloaded to your ~/.sourced/compose-files directory. It is now the active compose file.")
+	fmt.Println("To update your current installation use `sourced restart`")
 	return nil
 }
 
@@ -76,6 +77,7 @@ func (c *composeSetDefaultCmd) Execute(args []string) error {
 	}
 
 	fmt.Println("Active docker compose file was changed successfully.")
+	fmt.Println("To update your current installation use `sourced restart`")
 	return nil
 }
 

--- a/cmd/sourced/cmd/restart.go
+++ b/cmd/sourced/cmd/restart.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"context"
+
+	"github.com/src-d/sourced-ce/cmd/sourced/compose"
+)
+
+type restartCmd struct {
+	Command `name:"restart" short-description:"Update current installation according to the active docker compose file" long-description:"Update current installation according to the active docker compose file."`
+}
+
+func (c *restartCmd) Execute(args []string) error {
+	return compose.Run(context.Background(), "up", "--force-recreate")
+}
+
+func init() {
+	rootCmd.AddCommand(&restartCmd{})
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       # use main db
       GITCOLLECTOR_METRICS_DB_URI: postgresql://superset:superset@postgres:5432/superset?sslmode=disable
       GITCOLLECTOR_HALF_CPU: 'true'
+      GITCOLLECTOR_NO_UPDATES: 'true'
       LOG_LEVEL: debug
     depends_on:
       - postgres

--- a/docs/usage/commands.md
+++ b/docs/usage/commands.md
@@ -98,6 +98,10 @@ You can activate any other with `compose set`.
 
 Sets the active `docker-compose.yml` file.
 
+#### sourced restart
+
+Updates current installation according to the active docker compose file.
+
 
 ## Open Interfaces
 


### PR DESCRIPTION
Fix: #27

Currently the command would just do `up --force-recreate` which would
re-create containers according to the changes in docker-compose.yml file

Signed-off-by: Maxim Sukharev <max@smacker.ru>