### PR TITLE
Enhance commands desc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,17 +11,17 @@ Initial release. It includes a `docker-compose.yml` file to deploy source{d} CE 
 
 The `sourced` binary is a wrapper for Docker Compose that downloads the `docker-compose.yml` file from this repository, and includes the following sub commands:
 
-- `init`: Install and initialize containers
-  - `local`: Install and initialize containers to analyze local repositories
-  - `orgs`: Install and initialize containers to analyze GitHub organizations
-- `status`: Shows status of the components
-- `stop`: Stop running containers
-- `start`: Start stopped containers
+- `init`: Initialize source{d} to work on local or Github orgs datasets
+  - `local`: Initialize source{d} to analyze local repositories
+  - `orgs`: Initialize source{d} to analyze GitHub organizations
+- `status`: Show the status of all components
+- `stop`: Stop any running components
+- `start`: Start any stopped components
 - `web`: Open the web interface in your browser
-- `sql`: Open a MySQL client connected to gitbase
-- `prune`: Stop and remove containers and resources
-- `workdirs` List working directories
-- `compose`: Manage docker compose files
+- `sql`: Open a MySQL client connected to a SQL interface for Git
+- `prune`: Stop and remove components and resources
+- `workdirs` List all working directories
+- `compose`: Manage source{d} docker compose files
   - `download`: Download docker compose files
   - `list`: List the downloaded docker compose files
   - `set`: Set the active docker compose file

--- a/cmd/sourced/cmd/compose.go
+++ b/cmd/sourced/cmd/compose.go
@@ -9,7 +9,7 @@ import (
 )
 
 type composeCmd struct {
-	cli.PlainCommand `name:"compose" short-description:"Manage docker compose files" long-description:"Manage docker compose files"`
+	cli.PlainCommand `name:"compose" short-description:"Manage source{d} docker compose files" long-description:"Manage source{d} docker compose files"`
 }
 
 type composeDownloadCmd struct {

--- a/cmd/sourced/cmd/init.go
+++ b/cmd/sourced/cmd/init.go
@@ -17,11 +17,11 @@ import (
 )
 
 type initCmd struct {
-	cli.PlainCommand `name:"init" short-description:"Install and initialize containers" long-description:"Install and initialize containers"`
+	cli.PlainCommand `name:"init" short-description:"Initialize source{d} to work on local or Github orgs datasets" long-description:"Initialize source{d} to work on local or Github orgs datasets"`
 }
 
 type initLocalCmd struct {
-	Command `name:"local" short-description:"Install and initialize containers to analyze local repositories" long-description:"Install, initialize, and start all the required docker containers, networks, volumes, and images.\n\nThe repos directory argument must point to a directory containing git repositories.\nIf it's not provided, the current working directory will be used."`
+	Command `name:"local" short-description:"Initialize source{d} to analyze local repositories" long-description:"Install, initialize, and start all the required docker containers, networks, volumes, and images.\n\nThe repos directory argument must point to a directory containing git repositories.\nIf it's not provided, the current working directory will be used."`
 
 	Args struct {
 		Reposdir string `positional-arg-name:"workdir"`
@@ -80,7 +80,7 @@ func (c *initLocalCmd) reposdirArg() (string, error) {
 }
 
 type initOrgsCmd struct {
-	Command `name:"orgs" short-description:"Install and initialize containers to analyze GitHub organizations" long-description:"Install, initialize, and start all the required docker containers, networks, volumes, and images.\n\nThe orgs argument must a comma-separated list of GitHub organization names to be analyzed."`
+	Command `name:"orgs" short-description:"Initialize source{d} to analyze GitHub organizations" long-description:"Install, initialize, and start all the required docker containers, networks, volumes, and images.\n\nThe orgs argument must a comma-separated list of GitHub organization names to be analyzed."`
 
 	Token string `short:"t" long:"token" env:"SOURCED_GITHUB_TOKEN" description:"Github token for the passed organizations. It should be granted with 'repo' and 'read:org' scopes." required:"true"`
 	Args  struct {

--- a/cmd/sourced/cmd/prune.go
+++ b/cmd/sourced/cmd/prune.go
@@ -8,7 +8,7 @@ import (
 )
 
 type pruneCmd struct {
-	Command `name:"prune" short-description:"Stop and remove containers and resources" long-description:"Stops containers and removes containers, networks, volumes and configuration created by 'init' for the current working directory.\nTo delete resources for all working directories pass --all flag.\nImages are not deleted unless you specify the --images flag."`
+	Command `name:"prune" short-description:"Stop and remove components and resources" long-description:"Stops containers and removes containers, networks, volumes and configuration created by 'init' for the current working directory.\nTo delete resources for all working directories pass --all flag.\nImages are not deleted unless you specify the --images flag."`
 
 	All    bool `short:"a" long:"all" description:"Remove containers and resources for all working directories"`
 	Images bool `long:"images" description:"Remove docker images"`

--- a/cmd/sourced/cmd/root.go
+++ b/cmd/sourced/cmd/root.go
@@ -14,7 +14,7 @@ const name = "sourced"
 
 var version = "master"
 
-var rootCmd = cli.NewNoDefaults(name, "source{d} CE and EE installer")
+var rootCmd = cli.NewNoDefaults(name, "source{d} Community Edition & Enterprise Edition CLI client")
 
 // Init sets the version rewritten by the CI build and adds default sub commands
 func Init(v, build string) {

--- a/cmd/sourced/cmd/sql.go
+++ b/cmd/sourced/cmd/sql.go
@@ -7,7 +7,7 @@ import (
 )
 
 type sqlCmd struct {
-	Command `name:"sql" short-description:"Open a MySQL client connected to gitbase" long-description:"Open a MySQL client connected to gitbase"`
+	Command `name:"sql" short-description:"Open a MySQL client connected to a SQL interface for Git" long-description:"Open a MySQL client connected to a SQL interface for Git"`
 }
 
 func (c *sqlCmd) Execute(args []string) error {

--- a/cmd/sourced/cmd/start.go
+++ b/cmd/sourced/cmd/start.go
@@ -8,7 +8,7 @@ import (
 )
 
 type startCmd struct {
-	Command `name:"start" short-description:"Start stopped containers" long-description:"Start stopped containers.\nThe containers must be initialized before with 'init'."`
+	Command `name:"start" short-description:"Start any stopped components" long-description:"Start any stopped components.\nThe containers must be initialized before with 'init'."`
 }
 
 func (c *startCmd) Execute(args []string) error {

--- a/cmd/sourced/cmd/status.go
+++ b/cmd/sourced/cmd/status.go
@@ -7,7 +7,7 @@ import (
 )
 
 type statusCmd struct {
-	Command `name:"status" short-description:"Shows status of the components" long-description:"Shows status of the components"`
+	Command `name:"status" short-description:"Show the status of all components" long-description:"Show the status of all components"`
 }
 
 func (c *statusCmd) Execute(args []string) error {

--- a/cmd/sourced/cmd/stop.go
+++ b/cmd/sourced/cmd/stop.go
@@ -7,7 +7,7 @@ import (
 )
 
 type stopCmd struct {
-	Command `name:"stop" short-description:"Stop running containers" long-description:"Stop running containers without removing them.\nThey can be started again with 'start'."`
+	Command `name:"stop" short-description:"Stop any running components" long-description:"Stop any running components without removing them.\nThey can be started again with 'start'."`
 }
 
 func (c *stopCmd) Execute(args []string) error {

--- a/cmd/sourced/cmd/workdirs.go
+++ b/cmd/sourced/cmd/workdirs.go
@@ -7,7 +7,7 @@ import (
 )
 
 type workdirsCmd struct {
-	Command `name:"workdirs" short-description:"List working directories" long-description:"List previously initialized working directories."`
+	Command `name:"workdirs" short-description:"List all working directories" long-description:"List all the previously initialized working directories."`
 }
 
 func (c *workdirsCmd) Execute(args []string) error {


### PR DESCRIPTION
fix #94

```
Usage:
  sourced [OPTIONS] <command>

source{d} Community Edition & Enterprise Edition CLI client

Help Options:
  -h, --help  Show this help message

Available commands:
  completion  print bash completion script
  compose     Manage source{d} docker compose files
  init        Initialize source{d} to work on local or Github orgs datasets
  prune       Stop and remove components and resources
  sql         Open a MySQL client connected to a SQL interface for Git
  start       Start any stopped components
  status      Show the status of all components
  stop        Stop any running components
  version     print version
  web         Open the web interface in your browser
  workdirs    List all working directories
```

[`version`]( https://github.com/src-d/go-cli/blob/master/version.go#L10) and [`completion`](https://github.com/src-d/go-cli/blob/master/completion.go#L14) comes from [src-d/go-cli](https://github.com/src-d/go-cli), so I'm not sure if they can be overrided.
