### PR TITLE
Fix link in docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@
     - [Run **source{d} CE**](./quickstart/3-init-sourced.md)
     - [Explore Your Data](./quickstart/4-explore-sourced.md)
 
-## Advanced Usage
+## Usage
 * [sourced Command Reference](./usage/commands.md)
 * [Multiple Datasets](./usage/multiple-datasets.md)
 * [SQL Examples](./usage/examples.md)


### PR DESCRIPTION
caused by https://github.com/src-d/sourced-ui/issues/172

Those docs does not look like that "advanced"

![image](https://user-images.githubusercontent.com/2437584/60240446-4a053780-98b1-11e9-94e4-69a5a71d17b3.png)
