### PR TITLE
Run SQL query directly instead of opening REPL

### DIFF
--- a/cmd/sourced/cmd/sql.go
+++ b/cmd/sourced/cmd/sql.go
@@ -8,10 +8,19 @@ import (
 
 type sqlCmd struct {
 	Command `name:"sql" short-description:"Open a MySQL client connected to a SQL interface for Git" long-description:"Open a MySQL client connected to a SQL interface for Git"`
+
+	Args struct {
+		Query string `positional-arg-name:"query" description:"SQL query to be run by the SQL interface for Git"`
+	} `positional-args:"yes"`
 }
 
 func (c *sqlCmd) Execute(args []string) error {
-	return compose.Run(context.Background(), "exec", "gitbase", "mysql")
+	command := []string{"exec", "gitbase", "mysql"}
+	if c.Args.Query != "" {
+		command = append(command, "--execute", c.Args.Query)
+	}
+
+	return compose.Run(context.Background(), command...)
 }
 
 func init() {

--- a/docs/usage/commands.md
+++ b/docs/usage/commands.md
@@ -111,6 +111,17 @@ It only recreates the component containers, keeping all your data, as charts, da
 
 Opens a MySQL client connected to gitbase.
 
+You can also pass a SQL query to be run by gitbase instead of opening the REPL, e.g.
+```shell
+$ sourced sql "show databases"
+
++----------+
+| Database |
++----------+
+| gitbase  |
++----------+
+```
+
 **source{d} CE** SQL supports a [UAST](#babelfish-uast) function that returns a Universal AST for the selected source text. UAST values are returned as binary blobs and are best visualized in the [SQL Lab, from the web interface](.../quickstart/4-explore-sourced.md#sql-lab-querying-code) rather than the CLI where are seen as binary data.
 
 ### sourced web


### PR DESCRIPTION
fix #117

If passed a query, it's run by `mysql` inside `gitbase`, instead of opening `mysql` REPL.