### PR TITLE
See logs from source{d} components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The `sourced` binary is a wrapper for Docker Compose that downloads the `docker-
 - `status`: Show the status of all components
 - `stop`: Stop any running components
 - `start`: Start any stopped components
+- `logs`: Show logs from components
 - `web`: Open the web interface in your browser
 - `sql`: Open a MySQL client connected to a SQL interface for Git
 - `prune`: Stop and remove components and resources

--- a/cmd/sourced/cmd/logs.go
+++ b/cmd/sourced/cmd/logs.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"context"
+
+	"github.com/src-d/sourced-ce/cmd/sourced/compose"
+)
+
+type logsCmd struct {
+	Command `name:"logs" short-description:"Fetch the logs of source{d}" long-description:"Fetch the logs of source{d}"`
+
+	Follow bool `short:"f" long:"follow" description:"Follow log output"`
+	Args   struct {
+		Components []string `positional-arg-name:"component" description:"Component names from where to fetch logs"`
+	} `positional-args:"yes"`
+}
+
+func (c *logsCmd) Execute(args []string) error {
+	command := []string{"logs"}
+
+	if c.Follow {
+		command = append(command, "--follow")
+	}
+
+	if components := c.Args.Components; len(components) > 0 {
+		command = append(command, components...)
+	}
+
+	return compose.Run(context.Background(), command...)
+}
+
+func init() {
+	rootCmd.AddCommand(&logsCmd{})
+}

--- a/cmd/sourced/cmd/logs.go
+++ b/cmd/sourced/cmd/logs.go
@@ -7,7 +7,7 @@ import (
 )
 
 type logsCmd struct {
-	Command `name:"logs" short-description:"Fetch the logs of source{d}" long-description:"Fetch the logs of source{d}"`
+	Command `name:"logs" short-description:"Fetch the logs of source{d} components" long-description:"Fetch the logs of source{d} components"`
 
 	Follow bool `short:"f" long:"follow" description:"Follow log output"`
 	Args   struct {

--- a/docs/usage/commands.md
+++ b/docs/usage/commands.md
@@ -64,11 +64,11 @@ If you want to completely uninstall `sourced` you must also delete the `~/.sourc
 
 ### sourced logs
 
-Show logs from components.
+Show logs from source{d} components.
 
-If it's passed `--follow`, the logs are shown as they are logged till you exit with `Ctrl+C`.
+If `--follow` is used the logs are shown as they are logged until you exit with `Ctrl+C`.
 
-It can be passed only some component names, to see only its logs.
+You can optionally pass component names to see only their logs.
 
 ```shell
 $ sourced logs

--- a/docs/usage/commands.md
+++ b/docs/usage/commands.md
@@ -62,6 +62,20 @@ Container images are not deleted unless you specify the `--images` flag.
 
 If you want to completely uninstall `sourced` you must also delete the `~/.sourced` directory.
 
+### sourced logs
+
+Show logs from components.
+
+If it's passed `--follow`, the logs are shown as they are logged till you exit with `Ctrl+C`.
+
+It can be passed only some component names, to see only its logs.
+
+```shell
+$ sourced logs
+$ sourced logs --follow
+$ sourced logs --follow gitbase bblfsh
+```
+
 
 ## Manage Configuration
 


### PR DESCRIPTION
Being able to access easily to `sourced` logs should be a must to avoid using other workarounds as suggested by https://forum.sourced.tech/t/lost-connection-to-mysql-server-during-query/51

This PR enables that feature by doing:
```shell
sourced logs [--follow] [component...]
```

