### PR TITLE
Add link to book a demo

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -20,5 +20,6 @@
 
 * [GitHub Repository](https://github.com/src-d/sourced-ce)
 * [Product Page](https://www.sourced.tech)
+* [Book a Demo](https://go.sourced.tech/community-demo)
 * [Get in Touch With Us](http://go.sourced.tech/contact)
 * [Join Us on Slack](https://sourced-community.slack.com/join/shared_invite/enQtMjc4Njk5MzEyNzM2LTFjNzY4NjEwZGEwMzRiNTM4MzRlMzQ4MmIzZjkwZmZlM2NjODUxZmJjNDI1OTcxNDAyMmZlNmFjODZlNTg0YWM)


### PR DESCRIPTION
Add a link to book a demo, as it was done in source{d} Engine and source{d} Lookout, now using the final link as got from Landing.