### PR TITLE
Clarify the necessity of Docker Compose in Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ This repository contains the code of **source{d} Community Edition (CE)** and it
 
 To run it you only need:
 
-1. To have Docker installed in your PC
+1. To have Docker installed in your PC (and Docker Compose in Windows)
 1. Download `sourced` binary (for your OS) from [our releases](https://github.com/src-d/sourced-ce/releases)
 1. Run it:
    ```bash

--- a/docs/quickstart/1-install-requirements.md
+++ b/docs/quickstart/1-install-requirements.md
@@ -13,6 +13,8 @@ Follow the instructions based on your OS:
 
 ## Docker Compose
 
-**source{d} CE** is deployed as Docker containers, using [Docker Compose](https://docs.docker.com/compose), but it is not required to have a local installation of Docker Compose; if it is not found it will be deployed inside a container.
+**source{d} CE** is deployed as Docker containers, using [Docker Compose](https://docs.docker.com/compose).
 
-If you prefer a local installation of Docker Compose, you can follow the [Docker Compose install guide](https://docs.docker.com/compose/install)
+In Linux and macOS, it is not required to have a local installation of Docker Compose, because if it is not found it will be deployed inside a container.
+
+In Windows, or if you prefer a local installation of Docker Compose, you can follow the [Docker Compose install guide](https://docs.docker.com/compose/install)


### PR DESCRIPTION
As found at [cmd/sourced/compose/compose.go#L114](https://github.com/src-d/sourced-ce/blob/master/cmd/sourced/compose/compose.go#L114), Docker Compose inside of a container is not available in Windows.

