### PR TITLE
Add a link to the 'next steps' in main README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,13 @@ This repository contains the code of **source{d} Community Edition \(CE\)** and 
 
 ### Contents
 
-* [Introduction](./#introduction)
-* [Quick Start](./#quick-start)
-* [Contributing](./#contributing)
-* [Community](./#community)
-* [Code of Conduct](./#code-of-conduct)
-* [License](./#license)
+* [Introduction](README.md#introduction)
+* [Quick Start](README.md#quick-start)
+- [Architecture](README.md#architecture)
+* [Contributing](README.md#contributing)
+* [Community](README.md#community)
+* [Code of Conduct](README.md#code-of-conduct)
+* [License](README.md#license)
 
 ## Quick Start
 
@@ -47,6 +48,8 @@ To run it you only need:
    And log in into [http://127.0.0.1:8088](http://127.0.0.1:8088) with login: `admin`, and password: `admin`.
 
 If you want more details of each step, you will find in the [**Quick Start Guide**](docs/quickstart/) all the steps to get started with **source{d} CE**, from the installation of its dependencies to running SQL queries to inspect git repositories.
+
+If you want to know more about **source{d} CE**, in the [next steps](docs/usage/README.md) section you will find some useful resources for guiding your experience using this tool.
 
 If you have any problem running **source{d} CE** you can take a look at our [Troubleshooting](docs/learn-more/troubleshooting.md) section, and our [source{d} Forum](https://forum.sourced.tech), where you can also ask for help when using **source{d} CE**. If you spotted a bug, or have a feature request, please [open an issue](https://github.com/src-d/sourced-ce/issues) to let us know about it.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@
   * [Install source{d} CE](quickstart/2-install-sourced.md)
   * [Run source{d} CE](quickstart/3-init-sourced.md)
   * [Explore Your Data](quickstart/4-explore-sourced.md)
+  * [Next steps](./usage/README.md)
 
 ## Usage
 

--- a/docs/usage/README.md
+++ b/docs/usage/README.md
@@ -3,6 +3,10 @@
 Once you know how to install and run **source{d} Community Edition**, you will find in this section some useful resources for guiding your first steps using this tool.
 
 - [`sourced` Command Reference](./commands.md)
-- [Using Multiple Datasets](./multiple-datasets.md)
+- [Using Multiple Datasets](./multiple-datasets.md) will show you how to analyze different datasets, no matter if they are stored locally or in GitHub.
 - [Some SQL Examples to Explore Your Dataset](./examples.md)
-- [Babelfish UAST](./bblfsh.md), how to understand code structure
+- [Babelfish UAST](./bblfsh.md), about how to extract code features and understand code structure in a language-agnostic way".
+
+If you are interested in the different components of **source{d} Community Edition**, you can read more about it in the [docs about architecture](../learn-more/architecture.md)
+
+Some common questions are answered in the [FAQ](../learn-more/faq.md), and common problems and how to solve them in the  [Troubleshooting](../learn-more/troubleshooting.md) guide. If you have any question about source{d} you can ask in our [source{d} Forum](https://forum.sourced.tech). If you spotted a bug, or have a feature request, please [open an issue](https://github.com/src-d/sourced-ce/issues) to let us know about it.


### PR DESCRIPTION
required by #126

See https://github.com/src-d/sourced-ce/issues/126#issuecomment-507810661 for the rationale behind this proposal.

**TL;DR**
Adding a link to `docs/usage/README.md` in our current `README.md#quickstart`, will clearly promote these contents in our quickstart from our main `README.md` (for people visiting our docs from GitHub) without adding extra repeated links (for our main group of visitors, reading our docs in the recommended GitBook).