### PR TITLE
Use alpine docker images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,7 +72,7 @@ services:
       - bblfsh
 
   redis:
-    image: redis:3.2
+    image: redis:5-alpine
     restart: unless-stopped
     ports:
       - 6379:6379
@@ -80,7 +80,7 @@ services:
       - redis:/data
 
   postgres:
-    image: postgres:10
+    image: postgres:10-alpine
     restart: unless-stopped
     environment:
       POSTGRES_DB: superset
@@ -92,7 +92,7 @@ services:
       - postgres:/var/lib/postgresql/data
 
   metadatadb:
-    image: postgres:10
+    image: postgres:10-alpine
     restart: unless-stopped
     environment:
       POSTGRES_DB: metadata


### PR DESCRIPTION
I don't see an issue for this but somebody suggested this change in empathy session.

Change images of redis and postgres to alpine to reduce disk and memory
footprint.
Also updated redis to newer version just in case.

I tested it with previously initialized workdir, all data is preserved.
