### PR TITLE
Make sourced-ui to depend on bblfsh-web

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -140,7 +140,7 @@ services:
       - metadatadb
       - redis
       - gitbase
-      - ghsync
+      - bblfsh-web
 
 volumes:
   gitbase_repositories:


### PR DESCRIPTION
Considering [container dependencies in docker-compose](https://docs.docker.com/compose/compose-file/#depends_on):
- `sourced-ui` should require `bblfsh-web`,
- `sourced-ui` does not directly depend on `ghsync`