### PR TITLE
Add SOURCED_DIR env var

### DIFF
--- a/cmd/sourced/dir/dir.go
+++ b/cmd/sourced/dir/dir.go
@@ -12,8 +12,12 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Path returns the absolute path for $HOME/.sourced
+// Path returns the absolute path for $SOURCED_DIR, or $HOME/.sourced if unset
 func Path() (string, error) {
+	if d := os.Getenv("SOURCED_DIR"); d != "" {
+		return filepath.Abs(d)
+	}
+
 	homedir, err := os.UserHomeDir()
 	if err != nil {
 		return "", errors.Wrap(err, "could not detect home directory")


### PR DESCRIPTION
Part of #131.

To have a clean environment for the tests, and to allow to run the tests without interfering with any existing installation, this PR adds a new SOURCED_DIR environment variable to replace the `~/.sourced` path.

Since this is something that will be used internally, and it's not supposed to be used by the end users, I didn't add it to the docs. Also, there are a few CLI messages that mention `~/.sourced`, I also left them as they are intentionally.