### PR TITLE
Disable tty in docker-compose exec when not in a terminal

### DIFF
--- a/cmd/sourced/cmd/sql.go
+++ b/cmd/sourced/cmd/sql.go
@@ -2,8 +2,11 @@ package cmd
 
 import (
 	"context"
+	"os"
 
 	"github.com/src-d/sourced-ce/cmd/sourced/compose"
+
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 type sqlCmd struct {
@@ -15,7 +18,11 @@ type sqlCmd struct {
 }
 
 func (c *sqlCmd) Execute(args []string) error {
-	command := []string{"exec", "gitbase", "mysql"}
+	command := []string{"exec"}
+	if !terminal.IsTerminal(int(os.Stdout.Fd())) || !terminal.IsTerminal(int(os.Stdin.Fd())) {
+		command = append(command, "-T")
+	}
+	command = append(command, "gitbase", "mysql")
 	if c.Args.Query != "" {
 		command = append(command, "--execute", c.Args.Query)
 	}

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/src-d/envconfig v1.0.0 // indirect
 	github.com/stretchr/testify v1.3.0 // indirect
 	github.com/x-cray/logrus-prefixed-formatter v0.5.2 // indirect
-	golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734 // indirect
+	golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734
 	golang.org/x/net v0.0.0-20190503192946-f4e77d36d62c // indirect
 	gopkg.in/src-d/go-cli.v0 v0.0.0-20190422143124-3a646154da79
 	gopkg.in/src-d/go-errors.v1 v1.0.0


### PR DESCRIPTION
Part of #131.

While trying to run `sourced sql "query"` with https://godoc.org/gotest.tools/icmd, the tests failed with:
```
Messages:   	the input device is not a TTY
              exit status 1
```

In this PR the `-T` option is added:
```
    -T                Disable pseudo-tty allocation. By default `docker-compose exec`
                      allocates a TTY.
```

Using `-T` when the stdout is not a TTY changes the output, but it is consistent with the `mysql` command:
```
$ sourced sql "select * from repositories limit 2"
+---------------------------------+
| repository_id                   |
+---------------------------------+
| github.com/bblfsh/lua-driver    |
| github.com/bblfsh/csharp-driver |
+---------------------------------+

$ sourced sql "select * from repositories limit 2"|cat
repository_id
github.com/bblfsh/lua-driver
github.com/bblfsh/scala-client



$ mysql -u root -h 127.0.0.1 -P 3306 gitbase --execute "select * from repositories limit 2"
+------------------------------+
| repository_id                |
+------------------------------+
| github.com/bblfsh/lua-driver |
| github.com/bblfsh/php-driver |
+------------------------------+

$ mysql -u root -h 127.0.0.1 -P 3306 gitbase --execute "select * from repositories limit 2"|cat
repository_id
github.com/bblfsh/lua-driver
github.com/bblfsh/csharp-driver
```
