### PR TITLE
Sort the output of 'sourced workdirs'

### DIFF
--- a/cmd/sourced/compose/workdir/common.go
+++ b/cmd/sourced/compose/workdir/common.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -150,6 +151,7 @@ func List() ([]string, error) {
 		}
 	}
 
+	sort.Strings(res)
 	return res, nil
 }
 


### PR DESCRIPTION
Part of #131.

While writing tests I realized the output of `sourced workdirs` was not sorted, and it makes sense to make it so.