### PR TITLE
Add superset client to end to end tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ go 1.12
 replace gotest.tools => gotest.tools v0.0.0-20181223230014-1083505acf35
 
 require (
+	github.com/PuerkitoBio/goquery v1.5.0
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/golang/protobuf v1.3.1 // indirect
 	github.com/google/btree v1.0.0 // indirect
@@ -28,7 +29,7 @@ require (
 	github.com/stretchr/testify v1.3.0
 	github.com/x-cray/logrus-prefixed-formatter v0.5.2 // indirect
 	golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734
-	golang.org/x/net v0.0.0-20190503192946-f4e77d36d62c // indirect
+	golang.org/x/net v0.0.0-20190503192946-f4e77d36d62c
 	gopkg.in/src-d/go-cli.v0 v0.0.0-20190422143124-3a646154da79
 	gopkg.in/src-d/go-errors.v1 v1.0.0
 	gopkg.in/src-d/go-log.v1 v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,7 @@
+github.com/PuerkitoBio/goquery v1.5.0 h1:uGvmFXOA73IKluu/F84Xd1tt/z07GYm8X49XKHP7EJk=
+github.com/PuerkitoBio/goquery v1.5.0/go.mod h1:qD2PgZ9lccMbQlc7eEOjaeRlFQON7xY8kdmcsrnKqMg=
+github.com/andybalholm/cascadia v1.0.0 h1:hOCXnnZ5A+3eVDX8pvgl4kofXv2ELss0bKcqRySc45o=
+github.com/andybalholm/cascadia v1.0.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -66,7 +70,9 @@ github.com/x-cray/logrus-prefixed-formatter v0.5.2/go.mod h1:2duySbKsL6M18s5GU7V
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734 h1:p/H982KKEjUnLJkM3tt/LemDnOc1GiZL5FCVlORJ5zo=
 golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3 h1:0GoQqolDA55aaLxZyTzK/Y2ePZzZTUrRacwib7cNsYQ=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=

--- a/test/superset.go
+++ b/test/superset.go
@@ -1,0 +1,132 @@
+package test
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+
+	"github.com/PuerkitoBio/goquery"
+	"golang.org/x/net/publicsuffix"
+)
+
+type supersetClient struct {
+	*http.Client
+	csrf string
+}
+
+func newSupersetClient() (*supersetClient, error) {
+	// Superset client needs a session cookie
+	jar, err := cookiejar.New(&cookiejar.Options{PublicSuffixList: publicsuffix.List})
+	if err != nil {
+		return nil, err
+	}
+
+	client := &http.Client{
+		Jar: jar,
+	}
+
+	// To POST in /login we need to first GET /login, read the hidden CSRF value
+	// from the HTML, and send it back in the POST
+	res, err := client.Get("http://127.0.0.1:8088/login/")
+	if err != nil {
+		return nil, err
+	}
+
+	doc, err := goquery.NewDocumentFromReader(res.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	csrf, ok := doc.Find("input#csrf_token").First().Attr("value")
+	if !ok {
+		return nil, fmt.Errorf("CSRF token was not found in the /login page")
+	}
+
+	res, err = client.PostForm("http://127.0.0.1:8088/login/", url.Values{
+		"csrf_token": {csrf},
+		"username":   {"admin"},
+		"password":   {"admin"},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// After a successful POST the client is authenticated and can be used to call
+	// the API
+	return &supersetClient{client, csrf}, nil
+}
+
+func (c *supersetClient) dashboards() ([]string, error) {
+	res, err := c.Get("http://127.0.0.1:8088/dashboard/api/read")
+	if err != nil {
+		return nil, err
+	}
+
+	var decoded struct {
+		Result []struct {
+			Link string `json:"dashboard_link"`
+		}
+	}
+
+	err = json.NewDecoder(res.Body).Decode(&decoded)
+	if err != nil {
+		return nil, err
+	}
+
+	links := []string{}
+	for _, result := range decoded.Result {
+		links = append(links, result.Link)
+	}
+
+	return links, nil
+}
+
+func (c *supersetClient) sql(query, dbId, schema string) ([]map[string]interface{}, error) {
+	res, err := c.PostForm("http://127.0.0.1:8088/superset/sql_json/", url.Values{
+		//"client_id":      {""},
+		"database_id": {dbId},
+		"json":        {"true"},
+		"runAsync":    {"false"},
+		"schema":      {schema},
+		"sql":         {query},
+		//"sql_editor_id":  {"jzl0KCm5Z"},
+		//"tab":            {"Untitled Query 2"},
+		//"tmp_table_name": {""},
+		//"select_as_cta":  {"false"},
+		//"templateParams": {"{}"},
+		//"queryLimit": {"1000"},
+
+		"csrf_token": {c.csrf},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var decoded struct {
+		Status string
+		Error  string
+		Data   []map[string]interface{}
+	}
+
+	err = json.NewDecoder(res.Body).Decode(&decoded)
+	if err != nil {
+		return nil, err
+	}
+
+	if decoded.Status != "success" {
+		return nil, fmt.Errorf("/sql_json endpoint returned an error: " + decoded.Error)
+	}
+
+	return decoded.Data, nil
+}
+
+func (c *supersetClient) gitbase(query string) ([]map[string]interface{}, error) {
+	return c.sql(query, "1", "gitbase")
+}
+
+func (c *supersetClient) metadata(query string) ([]map[string]interface{}, error) {
+	return c.sql(query, "2", "public")
+}


### PR DESCRIPTION
Part of #131.

This PR adds a client to use the superset API from the end to end tests.
For now it checks the list of dashboards, and SQL queries.

Next step would be to call the bblfsh-web endpoint on superset to test that it can parse files.