### PR TITLE
User friendly error when .sourced dir doesn't exist

### DIFF
--- a/cmd/sourced/cmd/root.go
+++ b/cmd/sourced/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/src-d/sourced-ce/cmd/sourced/compose/workdir"
+	"github.com/src-d/sourced-ce/cmd/sourced/dir"
 	"github.com/src-d/sourced-ce/cmd/sourced/format"
 
 	"gopkg.in/src-d/go-cli.v0"
@@ -42,7 +43,7 @@ type Command struct {
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	if err := rootCmd.Run(os.Args); err != nil {
-		if workdir.ErrMalformed.Is(err) {
+		if workdir.ErrMalformed.Is(err) || dir.ErrNotExist.Is(err) {
 			fmt.Println(format.Colorize(
 				format.Red,
 				`Cannot perform this action, source{d} needs to be initialized first with the 'init' sub command`,

--- a/cmd/sourced/compose/workdir/local.go
+++ b/cmd/sourced/compose/workdir/local.go
@@ -7,7 +7,7 @@ import (
 	"encoding/hex"
 )
 
-// Init creates a working directory in ~/.sourced for the given repositories
+// InitWithPath creates a working directory in ~/.sourced for the given repositories
 // directory. The working directory will contain a docker-compose.yml and a
 // .env file.
 // If the directory is already initialized the function returns with no error.

--- a/cmd/sourced/dir/dir.go
+++ b/cmd/sourced/dir/dir.go
@@ -10,7 +10,11 @@ import (
 	"path/filepath"
 
 	"github.com/pkg/errors"
+	goerrors "gopkg.in/src-d/go-errors.v1"
 )
+
+// ErrNotExist is returned when .sourced dir does not exists
+var ErrNotExist = goerrors.NewKind("%s does not exist")
 
 // Path returns the absolute path for $SOURCED_DIR, or $HOME/.sourced if unset
 func Path() (string, error) {
@@ -23,7 +27,13 @@ func Path() (string, error) {
 		return "", errors.Wrap(err, "could not detect home directory")
 	}
 
-	return filepath.Join(homedir, ".sourced"), nil
+	srcdDir := filepath.Join(homedir, ".sourced")
+	_, err = os.Lstat(srcdDir)
+	if os.IsNotExist(err) {
+		return "", ErrNotExist.New(srcdDir)
+	}
+
+	return srcdDir, nil
 }
 
 // DownloadURL downloads the given url to a file to the


### PR DESCRIPTION
Fix: #144

I tested it only manually. See #151 and #152 