### PR TITLE
Fix Makefile rules for integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,11 @@ GOTEST_INTEGRATION = $(GOTEST_BASE) -tags="forceposix integration"
 
 OS := $(shell uname)
 
+# override clean target from CI to avoid executing `go clean`
+# see https://github.com/src-d/sourced-ce/pull/154
+clean:
+	rm -rf $(BUILD_PATH) $(BIN_PATH) $(VENDOR_PATH)
+
 ifeq ($(OS),Darwin)
 test-integration-clean:
 	$(eval TMPDIR_INTEGRATION_TEST := $(PWD)/integration-test-tmp)


### PR DESCRIPTION
Fix #152

Go clean doesn't work with go modules and it doesn't make much sense to
run it when modules are used.

Ref: https://github.com/golang/go/issues/31002

Because sourced-ce uses go modules for dependency resolution it is
expected that GO111MODULE is enabled.

This commit removes running `go clean` and executes `rm` only.

Signed-off-by: Maxim Sukharev <max@smacker.ru>