### PR TITLE
Add build tag to run e2e tests separately

### DIFF
--- a/test/commander.go
+++ b/test/commander.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package test
 
 import (

--- a/test/common.go
+++ b/test/common.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package test
 
 import (

--- a/test/init_local_test.go
+++ b/test/init_local_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package test
 
 import (

--- a/test/init_orgs_test.go
+++ b/test/init_orgs_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package test
 
 import (

--- a/test/superset.go
+++ b/test/superset.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package test
 
 import (


### PR DESCRIPTION
Part of #131.

Fix #151.

With build tags the normal `go test` skips the end to end tests.