### PR TITLE
Use a custom `docker-file.override.yml`

### DIFF
--- a/cmd/sourced/compose/file/file.go
+++ b/cmd/sourced/compose/file/file.go
@@ -69,6 +69,33 @@ func InitDefault() (string, error) {
 	return activeFilePath, nil
 }
 
+// InitDefaultOverride returns the path of the default docker-compose.override.yml file,
+// if it does not exists, it is created.
+func InitDefaultOverride() (string, error) {
+	composeDirPath, err := dir()
+	if err != nil {
+		return "", err
+	}
+
+	globalOverridePath := filepath.Join(composeDirPath, activeDir, "docker-compose.override.yml")
+
+	_, err = os.Stat(globalOverridePath)
+	if err == nil {
+		return globalOverridePath, nil
+	}
+
+	if !os.IsNotExist(err) {
+		return "", errors.Wrap(err, "could not read the global docker-compose.override.yml file")
+	}
+
+	content := []byte(`version: '3.2'`)
+	if err := ioutil.WriteFile(globalOverridePath, content, 0644); err != nil {
+		return "", errors.Wrap(err, "could not create the global docker-compose.override.yml file")
+	}
+
+	return globalOverridePath, nil
+}
+
 // Download downloads the docker-compose.yml file from the given revision
 // or URL. The file is set as the active compose file.
 func Download(revOrURL RevOrURL) error {


### PR DESCRIPTION
blocks https://github.com/src-d/sourced-ui/pull/221
required by https://github.com/src-d/sourced-ce/issues/26

In order to use the default feature of Docker Compose to automatically load an extra `docker-compose.override.yml` file (docs [_multiple-compose-files_](https://docs.docker.com/compose/extends/#understanding-multiple-compose-files)), if this PR is accepted, it will be created a default (empty) `docker-compose.override.yml`, that will be linked in the workdirs (as done with the active `docker-compose.yml`)

The default `docker-compose.override.yml` is generated using the same version than the active `docker-compose.yml`

Usage:
1. User inits
1. then `~/.sourced/compose-files/__active__/docker-compose.override.yml` is modified
1. apply changes with `sourced restart`

I think we can consider this as an internal feature (not documented), used for people willing to manually modify the `~/.sourced/compose-files/__active__/docker-compose.yml`, that is also not documented.
