### PR TITLE
Use info as default logging level

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       GITCOLLECTOR_METRICS_DB_URI: postgresql://superset:superset@postgres:5432/superset?sslmode=disable
       GITCOLLECTOR_HALF_CPU: 'true'
       GITCOLLECTOR_NO_UPDATES: 'true'
-      LOG_LEVEL: debug
+      LOG_LEVEL: ${LOG_LEVEL:-info}
     depends_on:
       - postgres
     volumes:
@@ -44,6 +44,7 @@ services:
       GHSYNC_POSTGRES_PASSWORD: metadata
       GHSYNC_POSTGRES_HOST: metadatadb
       GHSYNC_POSTGRES_PORT: 5432
+      LOG_LEVEL: ${LOG_LEVEL:-info}
 
   gitbase:
     image: srcd/gitbase:v0.23.1
@@ -53,6 +54,7 @@ services:
     environment:
       BBLFSH_ENDPOINT: bblfsh:9432
       SIVA: ${GITBASE_SIVA}
+      GITBASE_LOG_LEVEL: ${LOG_LEVEL:-info}
     depends_on:
       - bblfsh
     volumes:


### PR DESCRIPTION
required by https://github.com/src-d/sourced-ce/issues/142

When approved, the logging level of `gitbase`, `gitcollector` and `ghsync` will be configurable with `LOG_LEVEL` environment var, e.g:
```shell
$ LOG_LEVEL=debug sourced init
```
will make that those components log all messages, and
```shell
$ LOG_LEVEL=error sourced init
```
will make that those components log only `error` more severe messages.

The rest of the components are blocked by certain issues, as described in causing https://github.com/src-d/sourced-ce/issues/142 