### PR TITLE
Handle different errors and provide nice error messages

### DIFF
--- a/cmd/sourced/cmd/root.go
+++ b/cmd/sourced/cmd/root.go
@@ -42,14 +42,31 @@ type Command struct {
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	if err := rootCmd.Run(os.Args); err != nil {
-		if workdir.ErrMalformed.Is(err) || dir.ErrNotExist.Is(err) {
-			fmt.Println(format.Colorize(
-				format.Red,
-				`Cannot perform this action, source{d} needs to be initialized first with the 'init' sub command`,
-			))
-		}
-
+	if err := dir.Prepare(); err != nil {
+		fmt.Println(err)
+		log(err)
 		os.Exit(1)
 	}
+
+	if err := rootCmd.Run(os.Args); err != nil {
+		log(err)
+		os.Exit(1)
+	}
+}
+
+func log(err error) {
+	switch {
+	case workdir.ErrMalformed.Is(err) || dir.ErrNotExist.Is(err):
+		printRed("Cannot perform this action, source{d} needs to be initialized first with the 'init' sub command")
+	case dir.ErrNotValid.Is(err):
+		printRed("Cannot perform this action, config directory is not valid")
+	case fmt.Sprintf("%T", err) == "*flags.Error":
+		// syntax error is already logged by go-cli
+	default:
+		printRed("Unexpected error")
+	}
+}
+
+func printRed(message string) {
+	fmt.Println(format.Colorize(format.Red, message))
 }

--- a/cmd/sourced/cmd/root.go
+++ b/cmd/sourced/cmd/root.go
@@ -63,7 +63,7 @@ func log(err error) {
 	case fmt.Sprintf("%T", err) == "*flags.Error":
 		// syntax error is already logged by go-cli
 	default:
-		printRed("Unexpected error")
+		// unknown errors have no special message
 	}
 }
 

--- a/cmd/sourced/cmd/workdirs.go
+++ b/cmd/sourced/cmd/workdirs.go
@@ -16,8 +16,11 @@ func (c *workdirsCmd) Execute(args []string) error {
 		return err
 	}
 
-	// ignore errors if active dir doesn't exist or unavailable
-	active, _ := workdir.Active()
+	active, err := workdir.Active()
+	if err != nil {
+		return err
+	}
+
 	for _, dir := range dirs {
 		if dir == active {
 			fmt.Printf("* %s\n", dir)

--- a/cmd/sourced/compose/workdir/common.go
+++ b/cmd/sourced/compose/workdir/common.go
@@ -125,7 +125,7 @@ func ActivePath() (string, error) {
 
 	resolvedPath, err := filepath.EvalSymlinks(path)
 	if os.IsNotExist(err) {
-		return "", ErrMalformed.New("active", "not found")
+		return "", ErrMalformed.New("active", err)
 	}
 
 	return resolvedPath, err

--- a/cmd/sourced/compose/workdir/common.go
+++ b/cmd/sourced/compose/workdir/common.go
@@ -353,8 +353,8 @@ func workdirsPath() (string, error) {
 	return filepath.Join(path, "workdirs"), nil
 }
 
-// function takes workdirs root and absolute path to workdir
-// return human-readable name
+// decodeName takes workdirs root and absolute path to workdir
+// return human-readable name. It returns an error if the path could not be built
 func decodeName(base, target string) (string, error) {
 	p, err := filepath.Rel(base, target)
 	if err != nil {

--- a/cmd/sourced/dir/dir.go
+++ b/cmd/sourced/dir/dir.go
@@ -1,5 +1,4 @@
-// Package dir provides functions to manage the $HOME/.sourced and /tmp/srcd
-// directories
+// Package dir provides functions to manage the config directories.
 package dir
 
 import (
@@ -13,13 +12,14 @@ import (
 	goerrors "gopkg.in/src-d/go-errors.v1"
 )
 
-// ErrNotExist is returned when .sourced dir does not exists
+// ErrNotExist is returned when config dir does not exists
 var ErrNotExist = goerrors.NewKind("%s does not exist")
 
 // ErrNotValid is returned when config dir is not valid
 var ErrNotValid = goerrors.NewKind("%s is not a valid config directory: %s")
 
 // Path returns the absolute path for $SOURCED_DIR, or $HOME/.sourced if unset
+// and returns an error if it does not exist or it could not be read.
 func Path() (string, error) {
 	srcdDir, err := path()
 	if err != nil {

--- a/cmd/sourced/dir/dir.go
+++ b/cmd/sourced/dir/dir.go
@@ -61,7 +61,11 @@ func Prepare() error {
 
 	err = validate(srcdDir)
 	if ErrNotExist.Is(err) {
-		return os.MkdirAll(srcdDir, os.ModePerm)
+		if err := os.MkdirAll(srcdDir, os.ModePerm); err != nil {
+			return ErrNotValid.New(srcdDir, err)
+		}
+
+		return nil
 	}
 
 	return err

--- a/cmd/sourced/dir/dir.go
+++ b/cmd/sourced/dir/dir.go
@@ -16,10 +16,31 @@ import (
 // ErrNotExist is returned when .sourced dir does not exists
 var ErrNotExist = goerrors.NewKind("%s does not exist")
 
+// ErrNotValid is returned when config dir is not valid
+var ErrNotValid = goerrors.NewKind("%s is not a valid config directory: %s")
+
 // Path returns the absolute path for $SOURCED_DIR, or $HOME/.sourced if unset
 func Path() (string, error) {
+	srcdDir, err := path()
+	if err != nil {
+		return "", err
+	}
+
+	if err := validate(srcdDir); err != nil {
+		return "", err
+	}
+
+	return srcdDir, nil
+}
+
+func path() (string, error) {
 	if d := os.Getenv("SOURCED_DIR"); d != "" {
-		return filepath.Abs(d)
+		abs, err := filepath.Abs(d)
+		if err != nil {
+			return "", errors.Wrap(err, fmt.Sprintf("could not resolve SOURCED_DIR='%s'", d))
+		}
+
+		return abs, nil
 	}
 
 	homedir, err := os.UserHomeDir()
@@ -27,13 +48,46 @@ func Path() (string, error) {
 		return "", errors.Wrap(err, "could not detect home directory")
 	}
 
-	srcdDir := filepath.Join(homedir, ".sourced")
-	_, err = os.Lstat(srcdDir)
-	if os.IsNotExist(err) {
-		return "", ErrNotExist.New(srcdDir)
+	return filepath.Join(homedir, ".sourced"), nil
+}
+
+// Prepare tries to create the config directory, returning an error if it could not
+// be created, or nill if already exist or was successfully created.
+func Prepare() error {
+	srcdDir, err := path()
+	if err != nil {
+		return err
 	}
 
-	return srcdDir, nil
+	err = validate(srcdDir)
+	if ErrNotExist.Is(err) {
+		return os.MkdirAll(srcdDir, os.ModePerm)
+	}
+
+	return err
+}
+
+// validate validates that the passed config dir path is valid
+func validate(path string) error {
+	info, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return ErrNotExist.New(path)
+	}
+
+	if err != nil {
+		return ErrNotValid.New(path, err)
+	}
+
+	readWriteAccessMode := os.FileMode(0700)
+	if info.Mode()&readWriteAccessMode != readWriteAccessMode {
+		return ErrNotValid.New(path, "it has no read-write access")
+	}
+
+	if !info.IsDir() {
+		return ErrNotValid.New(path, "it is not a directory")
+	}
+
+	return nil
 }
 
 // DownloadURL downloads the given url to a file to the


### PR DESCRIPTION
fix #160

current `sourced` could fail in different ways if `~/.sourced` does not exist, also some errors are not nice from the user pov.

The commits in this PR fixes:
- Make sure that `~/.sourced` dir can be created when:
  - running `init`
  - running `compose download`
  - downloading 'docker-compose' script (when no installed 'docker-compose')
- Return a proper error if the user tried to run web before init
- Return a proper error if `workdir.Active` failed
- Return a proper error if `__active__` does not exist
