### PR TITLE
Add bblfsh calls to end-to-end tests

### DIFF
--- a/test/init_local_test.go
+++ b/test/init_local_test.go
@@ -132,6 +132,18 @@ repo_b
 		req.NoError(err)
 		req.Equal("javascript", lang)
 	})
+
+	// Test gitbase can connect to bblfsh with a SQL query that uses UAST
+	s.T().Run("gitbase-bblfsh", func(t *testing.T) {
+		req := require.New(t)
+
+		rows, err := client.gitbase(
+			`SELECT UAST('console.log("hello");', 'javascript') AS uast`)
+		req.NoError(err)
+
+		req.Len(rows, 1)
+		req.NotEmpty(rows[0]["uast"])
+	})
 }
 
 func (s *InitLocalTestSuite) initGitRepo(path string) {

--- a/test/init_local_test.go
+++ b/test/init_local_test.go
@@ -123,6 +123,15 @@ repo_b
 			{"repository_id": "repo_b"},
 		}, rows)
 	})
+
+	// Test bblfsh queries through superset
+	s.T().Run("superset-bblfsh", func(t *testing.T) {
+		req := require.New(t)
+
+		lang, err := client.bblfsh("hello.js", `console.log("hello");`)
+		req.NoError(err)
+		req.Equal("javascript", lang)
+	})
 }
 
 func (s *InitLocalTestSuite) initGitRepo(path string) {

--- a/test/init_orgs_test.go
+++ b/test/init_orgs_test.go
@@ -160,4 +160,13 @@ github.com/golang-migrate/migrate
 
 		s.Equal("golang-migrate", rows[0]["login"])
 	})
+
+	// Test bblfsh queries through superset
+	s.T().Run("superset-bblfsh", func(t *testing.T) {
+		req := require.New(t)
+
+		lang, err := client.bblfsh("hello.js", `console.log("hello");`)
+		req.NoError(err)
+		req.Equal("javascript", lang)
+	})
 }

--- a/test/init_orgs_test.go
+++ b/test/init_orgs_test.go
@@ -169,4 +169,16 @@ github.com/golang-migrate/migrate
 		req.NoError(err)
 		req.Equal("javascript", lang)
 	})
+
+	// Test gitbase can connect to bblfsh with a SQL query that uses UAST
+	s.T().Run("gitbase-bblfsh", func(t *testing.T) {
+		req := require.New(t)
+
+		rows, err := client.gitbase(
+			`SELECT UAST('console.log("hello");', 'javascript') AS uast`)
+		req.NoError(err)
+
+		req.Len(rows, 1)
+		req.NotEmpty(rows[0]["uast"])
+	})
 }


### PR DESCRIPTION
Part of #131.

Adds calls to bblfsh though superset, and also adds SQL queries that require bblfsh to check that gitbase can connect to bblfsh.