### PR TITLE
Rise proper error when listing no workdirs

### DIFF
--- a/cmd/sourced/compose/workdir/common.go
+++ b/cmd/sourced/compose/workdir/common.go
@@ -182,6 +182,11 @@ func ListPaths() ([]string, error) {
 		dirs[path] = true
 		return nil
 	})
+
+	if os.IsNotExist(err) {
+		return nil, ErrMalformed.New(wpath, err)
+	}
+
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fix: #144
Related to https://github.com/src-d/sourced-ce/pull/162

Bug #144 was partially solved by #153, but it only asserted for the existence of `~/.sourced`, and not for also `~/.sourced/workdirs`, which could not exist.

If this PR is merged, the proper nice error will be shown if the user runs `sourced workdir` before running `init`.