### PR TITLE
Add symlink eval for tempdir in case of Windows

### DIFF
--- a/test/common.go
+++ b/test/common.go
@@ -32,12 +32,19 @@ type IntegrationSuite struct {
 }
 
 func (s *IntegrationSuite) SetupTest() {
-	var err error
-	s.TestDir, err = ioutil.TempDir("", strings.Replace(s.T().Name(), "/", "_", -1))
+	testDir, err := ioutil.TempDir("", strings.Replace(s.T().Name(), "/", "_", -1))
 	if err != nil {
 		log.Fatal(err)
 	}
 
+	if runtime.GOOS == "windows" {
+		testDir, err = filepath.EvalSymlinks(testDir)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	s.TestDir = testDir
 	s.Commander = &Commander{bin: srcdBin, sourcedDir: filepath.Join(s.TestDir, "sourced")}
 
 	// Instead of downloading the compose file, create a link to the local file


### PR DESCRIPTION
Fixes integration tests for Windows.

This closes #168 and closes #172.

On Windows tempdir is created in `C:\Users\WINDOW~1\AppData\Local\Temp`. The problem is that `C:\Users\WINDOW~1` is actually an alias for `C:\Users\Windows10` (see [here](https://superuser.com/questions/529400/how-does-progra1-path-notation-work)), but having different strings breaks extraction of relative path that breaks the identification of current active workdir.