### PR TITLE
Exclude forks by default

### DIFF
--- a/cmd/sourced/cmd/init.go
+++ b/cmd/sourced/cmd/init.go
@@ -17,7 +17,7 @@ import (
 )
 
 type initCmd struct {
-	cli.PlainCommand `name:"init" short-description:"Initialize source{d} to work on local or Github orgs datasets" long-description:"Initialize source{d} to work on local or Github orgs datasets"`
+	cli.PlainCommand `name:"init" short-description:"Initialize source{d} to work on local or GitHub orgs datasets" long-description:"Initialize source{d} to work on local or Github orgs datasets"`
 }
 
 type initLocalCmd struct {
@@ -77,8 +77,9 @@ func (c *initLocalCmd) reposdirArg() (string, error) {
 type initOrgsCmd struct {
 	Command `name:"orgs" short-description:"Initialize source{d} to analyze GitHub organizations" long-description:"Install, initialize, and start all the required docker containers, networks, volumes, and images.\n\nThe orgs argument must a comma-separated list of GitHub organization names to be analyzed."`
 
-	Token string `short:"t" long:"token" env:"SOURCED_GITHUB_TOKEN" description:"Github token for the passed organizations. It should be granted with 'repo' and 'read:org' scopes." required:"true"`
-	Args  struct {
+	Token     string `short:"t" long:"token" env:"SOURCED_GITHUB_TOKEN" description:"GitHub token for the passed organizations. It should be granted with 'repo' and 'read:org' scopes." required:"true"`
+	WithForks bool   `long:"with-forks" description:"Download GitHub forked repositories"`
+	Args      struct {
 		Orgs []string `required:"yes"`
 	} `positional-args:"yes" required:"1"`
 }
@@ -94,7 +95,7 @@ func (c *initOrgsCmd) Execute(args []string) error {
 		return err
 	}
 
-	wd, err := workdir.InitOrgs(orgs, c.Token)
+	wd, err := workdir.InitOrgs(orgs, c.Token, c.WithForks)
 	if err != nil {
 		return err
 	}

--- a/cmd/sourced/compose/workdir/factory.go
+++ b/cmd/sourced/compose/workdir/factory.go
@@ -30,7 +30,7 @@ func InitLocal(reposdir string) (*Workdir, error) {
 }
 
 // InitOrgs initializes the workdir for organizations and returns the Workdir instance
-func InitOrgs(orgs []string, token string) (*Workdir, error) {
+func InitOrgs(orgs []string, token string, withForks bool) (*Workdir, error) {
 	// be indifferent to the order of passed organizations
 	sort.Strings(orgs)
 	dirName := encodeDirName(strings.Join(orgs, ","))
@@ -39,6 +39,7 @@ func InitOrgs(orgs []string, token string) (*Workdir, error) {
 		Workdir:             dirName,
 		GithubOrganizations: orgs,
 		GithubToken:         token,
+		WithForks:           withForks,
 	}
 
 	return initialize(dirName, "orgs", envf)
@@ -110,6 +111,7 @@ type envFile struct {
 	ReposDir            string
 	GithubOrganizations []string
 	GithubToken         string
+	WithForks           bool
 }
 
 func (f *envFile) String() string {
@@ -120,6 +122,11 @@ func (f *envFile) String() string {
 		volumeType = "volume"
 		volumeSource = "gitbase_repositories"
 		gitbaseSiva = "true"
+	}
+
+	noForks := "true"
+	if f.WithForks {
+		noForks = "false"
 	}
 
 	// limit CPU for containers
@@ -153,11 +160,12 @@ func (f *envFile) String() string {
 	GITBASE_SIVA=%s
 	GITHUB_ORGANIZATIONS=%s
 	GITHUB_TOKEN=%s
+	NO_FORKS=%s
 	GITBASE_LIMIT_CPU=%s
 	GITCOLLECTOR_LIMIT_CPU=%s
 	GITBASE_LIMIT_MEM=%s
 	`, f.Workdir, volumeType, volumeSource, gitbaseSiva,
-		strings.Join(f.GithubOrganizations, ","), f.GithubToken,
+		strings.Join(f.GithubOrganizations, ","), f.GithubToken, noForks,
 		gitbaseLimitCPU, gitcollectorLimitCPU, gitbaseLimitMem)
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       # use main db
       GITCOLLECTOR_METRICS_DB_URI: postgresql://superset:superset@postgres:5432/superset?sslmode=disable
       GITCOLLECTOR_NO_UPDATES: 'true'
+      GITCOLLECTOR_NO_FORKS: ${NO_FORKS:-true}
       LOG_LEVEL: ${LOG_LEVEL:-info}
     depends_on:
       - postgres
@@ -31,7 +32,7 @@ services:
           cpus: ${GITCOLLECTOR_LIMIT_CPU:-0.0}
 
   ghsync:
-    image: srcd/ghsync:v0.2.0-rc.1
+    image: srcd/ghsync:v0.2.0-rc.2
     entrypoint: ['/bin/sh']
     # wait for db to be created
     # we need to use something like https://github.com/vishnubob/wait-for-it
@@ -47,6 +48,7 @@ services:
       GHSYNC_POSTGRES_PASSWORD: metadata
       GHSYNC_POSTGRES_HOST: metadatadb
       GHSYNC_POSTGRES_PORT: 5432
+      GHSYNC_NO_FORKS: ${NO_FORKS:-true}
       LOG_LEVEL: ${LOG_LEVEL:-info}
 
   gitbase:


### PR DESCRIPTION
Part of #109 which introduces a new flag but doesn't address status/restart issues due to big refactoring in another PR.

The command has flag `with-forks` instead of `no-forks` because
`go-flags` doesn't allow to set boolean variable into `true` by default

Signed-off-by: Maxim Sukharev <max@smacker.ru>