### PR TITLE
Adds monitoring of services when opening ui to eventually fail fast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,11 @@
 ## [Unreleased]
 <details>
   <summary>
-    Changes that have landed in master but are not yet released.
-    Click to see more.
+
+### Added
+
+- Add a monitoring of containers state while waiting for the web UI to open during initialization ([#147](https://github.com/src-d/sourced-ce/issues/147)).
+
   </summary>
 
 </details>

--- a/cmd/sourced/cmd/web.go
+++ b/cmd/sourced/cmd/web.go
@@ -139,20 +139,18 @@ func runMonitor(ch chan<- error) {
 		}
 	}
 
-	go func() {
-		var servicesBuf bytes.Buffer
-		if err := compose.RunWithIO(context.Background(),
-			os.Stdin, &servicesBuf, nil, "config", "--services"); err != nil {
-			ch <- errors.Wrap(err, "cannot get list of services")
-			return
-		}
+	var servicesBuf bytes.Buffer
+	if err := compose.RunWithIO(context.Background(),
+		os.Stdin, &servicesBuf, nil, "config", "--services"); err != nil {
+		ch <- errors.Wrap(err, "cannot get list of services")
+		return
+	}
 
-		services := strings.Split(strings.TrimSpace(servicesBuf.String()), "\n")
+	services := strings.Split(strings.TrimSpace(servicesBuf.String()), "\n")
 
-		for _, service := range services {
-			go runMonitorService(service, ch)
-		}
-	}()
+	for _, service := range services {
+		go runMonitorService(service, ch)
+	}
 }
 
 // OpenUI opens the browser with the UI.
@@ -166,7 +164,7 @@ func OpenUI(timeout time.Duration) error {
 	ch := make(chan error)
 	containerReady := err == nil
 
-	runMonitor(ch)
+	go runMonitor(ch)
 
 	go func() {
 		if !containerReady {

--- a/cmd/sourced/cmd/web.go
+++ b/cmd/sourced/cmd/web.go
@@ -79,12 +79,7 @@ func waitForContainer(stdout *bytes.Buffer) {
 	}
 }
 
-var newLineFormatter = regexp.MustCompile(`(\r\n|\r|\n)`)
 var stateExtractor = regexp.MustCompile(`(?m)^srcd-[\w\d]+.*(Up|Exit (\w+))`)
-
-func normalizeNewLine(s string) string {
-	return newLineFormatter.ReplaceAllString(s, "\n")
-}
 
 // runMonitor checks the status of the containers in order to early exit in case
 // an unrecoverable error occurs.
@@ -113,7 +108,7 @@ func runMonitor(ch chan<- error) {
 			}
 
 			matches := stateExtractor.FindAllStringSubmatch(
-				normalizeNewLine(strings.TrimSpace(stdout.String())), -1)
+				strings.TrimSpace(stdout.String()), -1)
 			for _, match := range matches {
 				state := match[1]
 
@@ -152,8 +147,7 @@ func runMonitor(ch chan<- error) {
 			return
 		}
 
-		services := strings.Split(normalizeNewLine(
-			strings.TrimSpace(servicesBuf.String())), "\n")
+		services := strings.Split(strings.TrimSpace(servicesBuf.String()), "\n")
 
 		for _, service := range services {
 			go runMonitorService(service, ch)

--- a/cmd/sourced/cmd/web.go
+++ b/cmd/sourced/cmd/web.go
@@ -102,24 +102,6 @@ func normalizeNewLine(s string) string {
 // ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 // srcd-l1vzzxjzl3nln2vudhlzztdlbi9qcm9qzwn0cy8uz28td29ya3nwywnll3nyyy9naxrodwiuy29tl3nln   /bin/bblfsh-web -addr :808 ...   Up                      0.0.0.0:9999->8080/tcp
 // 2vudhlzztdlbg_bblfsh-web_1
-// srcd-l1vzzxjzl3nln2vudhlzztdlbi9qcm9qzwn0cy8uz28td29ya3nwywnll3nyyy9naxrodwiuy29tl3nln   /tini -- bblfshd                 Up                      0.0.0.0:9432->9432/tcp
-// 2vudhlzztdlbg_bblfsh_1
-// srcd-l1vzzxjzl3nln2vudhlzztdlbi9qcm9qzwn0cy8uz28td29ya3nwywnll3nyyy9naxrodwiuy29tl3nln   /bin/sh -c sleep 10s && gh ...   Up
-// 2vudhlzztdlbg_ghsync_1
-// srcd-l1vzzxjzl3nln2vudhlzztdlbi9qcm9qzwn0cy8uz28td29ya3nwywnll3nyyy9naxrodwiuy29tl3nln   ./init.sh                        Up                      0.0.0.0:3306->3306/tcp
-// 2vudhlzztdlbg_gitbase_1
-// srcd-l1vzzxjzl3nln2vudhlzztdlbi9qcm9qzwn0cy8uz28td29ya3nwywnll3nyyy9naxrodwiuy29tl3nln   /bin/dumb-init -- /bin/sh  ...   Up
-// 2vudhlzztdlbg_gitcollector_1
-// srcd-l1vzzxjzl3nln2vudhlzztdlbi9qcm9qzwn0cy8uz28td29ya3nwywnll3nyyy9naxrodwiuy29tl3nln   /home/entrypoint.sh start- ...   Up                      0.0.0.0:10000->10000/tcp, 0.0.0.0:4040->4040/tcp, 8888/tcp
-// 2vudhlzztdlbg_gsc_1
-// srcd-l1vzzxjzl3nln2vudhlzztdlbi9qcm9qzwn0cy8uz28td29ya3nwywnll3nyyy9naxrodwiuy29tl3nln   docker-entrypoint.sh postgres    Up                      0.0.0.0:5433->5432/tcp
-// 2vudhlzztdlbg_metadatadb_1
-// srcd-l1vzzxjzl3nln2vudhlzztdlbi9qcm9qzwn0cy8uz28td29ya3nwywnll3nyyy9naxrodwiuy29tl3nln   docker-entrypoint.sh postgres    Up                      0.0.0.0:5432->5432/tcp
-// 2vudhlzztdlbg_postgres_1
-// srcd-l1vzzxjzl3nln2vudhlzztdlbi9qcm9qzwn0cy8uz28td29ya3nwywnll3nyyy9naxrodwiuy29tl3nln   docker-entrypoint.sh redis ...   Up                      0.0.0.0:6379->6379/tcp
-// 2vudhlzztdlbg_redis_1
-// srcd-l1vzzxjzl3nln2vudhlzztdlbi9qcm9qzwn0cy8uz28td29ya3nwywnll3nyyy9naxrodwiuy29tl3nln   /entrypoint.sh                   Up (health: starting)   0.0.0.0:8088->8088/tcp
-// 2vudhlzztdlbg_sourced-ui_1
 func runMonitor(ch chan<- error) {
 	runMonitorService := func(service string, ch chan<- error) {
 		for {

--- a/cmd/sourced/cmd/web.go
+++ b/cmd/sourced/cmd/web.go
@@ -79,7 +79,7 @@ func waitForContainer(stdout *bytes.Buffer) {
 	}
 }
 
-var stateExtractor = regexp.MustCompile(`(?m)^srcd-[\w\d]+.*(Up|Exit (\w+))`)
+var stateExtractor = regexp.MustCompile(`(?m)^srcd-\w+.*(Up|Exit (\d+))`)
 
 // runMonitor checks the status of the containers in order to early exit in case
 // an unrecoverable error occurs.


### PR DESCRIPTION
This closes #147.

When the spinner is running and the user is waiting for the ui to open, a monitoring of the state of the containers is performed in order to stop if an unexpected state occurs.

I also ran integration tests on windows.