### PR TITLE
Set tmpdir to shorter location to make integrations test work on Windows

### DIFF
--- a/run-integration-tests.bat
+++ b/run-integration-tests.bat
@@ -4,4 +4,10 @@
 go build -tags=forceposix -o build/sourced-ce_windows_amd64/sourced.exe ./cmd/sourced
 
 :: run tests
+set TMPDIR_INTEGRATION_TEST=C:\tmp
+:: see https://stackoverflow.com/questions/22948189/batch-getting-the-directory-is-not-empty-on-rmdir-command
+del /f /s /q %TMPDIR_INTEGRATION_TEST% 1>nul
+rmdir /s /q %TMPDIR_INTEGRATION_TEST%
+mkdir %TMPDIR_INTEGRATION_TEST%
+set TMP=%TMPDIR_INTEGRATION_TEST%
 go test -timeout 20m -parallel 1 -count 1 -tags="forceposix integration" github.com/src-d/sourced-ce/test/ -v


### PR DESCRIPTION
Closes #191.