### PR TITLE
Add a PR template with changelog reminder

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+
+
+
+---
+
+<!-- Please leave this template at the end of your description, checking the option that applies -->
+
+* [ ] I have updated the CHANGELOG file according to the conventions in [keepachangelog.com](https://keepachangelog.com)
+* [ ] This PR contains changes that do not require a mention in the CHANGELOG file


### PR DESCRIPTION
This adds a new PR template that will remind to fill the changelog, or explicitly say that the PR does not require a changelog entry.

A bit of a side note. The horizontal line requires blank line, `----`, blank line. With this markdown:
```


----

```
Github was getting rid of the first blank line, breaking the syntax of the horizontal line. That's why there are 3 blank lines at the top, to leave room for the description.

.

This is how it will look:

---

<!-- Please leave this template at the end of your description, checking the option that applies -->

* [ ] I have updated the CHANGELOG file according to the conventions in [keepachangelog.com](https://keepachangelog.com)
* [x] This PR contains changes that do not require a mention in the CHANGELOG file