### PR TITLE
Show CHANGELOG in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+The changes listed under `Unreleased` section have landed in master but are not yet released.
+
+
 ## [Unreleased]
 
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@
 * [Troubleshooting](learn-more/troubleshooting.md)
 * [Architecture](learn-more/architecture.md)
 * [Contribute](learn-more/contributing.md)
+* [Changelog](../CHANGELOG.md)
 * [License](../LICENSE.md)
 
 ## Resources


### PR DESCRIPTION
fix #65

Unhide 'unreleased' section as done in other projects like 'gitbase' i.e. [src-d/gitbase/CHANGELOG.md](https://github.com/src-d/gitbase/blob/ade8efccee0cf097be57da683bda229129d042d7/CHANGELOG.md)

It will look like as the following:
https://dpordomingo.gitbook.io/community-edition/learn-more/changelog
