### PR TITLE
[DOCS] Enhance the UX when restoring postgres db

### DIFF
--- a/docs/learn-more/contributing.md
+++ b/docs/learn-more/contributing.md
@@ -14,3 +14,26 @@ This project lists the important changes between releases in the [`CHANGELOG.md`
 
 If you open a PR, you should also add a brief summary in the `CHANGELOG.md` mentioning the new feature, change or bugfix that you proposed.
 
+
+## How To Restore Dashboards and Charts to Defaults
+
+The official way to restore **source{d} CE** to its initial state, is to remove the running components with
+`sourced prune --all`, and then init again with `sourced init`.
+
+In some circumstances you need to restore only the state modified from the UI (charts, dashboards, saved queries, users,
+roles, etcetera), using the default ones for the version of **source{d} CE** that you're currently using, and preserve
+the repositories and metadata fetched from GitHub organizations.
+
+To do so, you only need to delete the docker volume containing the PostgreSQL database, and restart **source{d} CE**.
+It can be done following these steps if you already have [Docker Compose](https://docs.docker.com/compose/) installed:
+
+```shell
+$ cd ~/.sourced/workdirs/__active__
+$ source .env
+$ docker-compose stop postgres
+$ docker-compose rm -f postgres
+$ ENV_PREFIX=`awk '{print tolower($0)}' <<< ${COMPOSE_PROJECT_NAME}`
+$ docker volume rm ${ENV_PREFIX}_postgres
+$ docker-compose up -d postgres
+$ docker-compose exec -u superset sourced-ui bash -c 'sleep 10s && python bootstrap.py'
+```

--- a/docs/learn-more/faq.md
+++ b/docs/learn-more/faq.md
@@ -6,7 +6,6 @@ _For tips and advices to deal with unexpected errors, please refer to_ [_Trouble
 
 * [Where Can I Find More Assistance to Run source{d} or Notify You About Any Issue or Suggestion?](faq.md#where-can-i-find-more-assistance-to-run-source-d-or-notify-you-about-any-issue-or-suggestion)
 * [How Can I Update My Version Of **source{d} CE**?](faq.md#how-can-i-update-my-version-of-source-d-ce)
-* [How To Restore Dashboards and Charts to Defaults](faq.md#how-to-restore-dashboards-and-charts-to-defaults)
 * [How to Update the Data from the Organizations That I'm Analyzing](faq.md#how-to-update-the-data-from-the-organizations-being-analyzed)
 * [Can I Query Gitbase or Babelfish with External Tools?](faq.md#can-i-query-gitbase-or-babelfish-with-external-tools)
 * [Where Can I Read More About the Web Interface?](faq.md#where-can-i-read-more-about-the-web-interface)
@@ -43,35 +42,10 @@ When there is a new release of **source{d} CE**, it is noticed every time a `sou
 3. run `sourced compose download`
 4. run `sourced restart` to apply the new configuration.
 
-This process will reinstall **source{d} CE** with the new components, but it will keep your data \(repositories, charts, dashboards, etc\). If you want to replace all the current dashboards with the ones from the release that you just installed, you have two alternatives:
+This process will reinstall **source{d} CE** with the new components, but it will keep your data (repositories, charts, dashboards, etc).
 
-* run `sourced prune --all` before running `sourced init`; but if you were using
+If you want to replace all the current dashboards with the ones from the release that you just installed, the official way to proceed is to run `sourced prune --all` before running `sourced init`; please, notice that it will also delete your saved queries and charts, and if you were using repositories and metadata downloaded from a GitHub organization, they will be deleted, and downloaded again.
 
-  repositories downloaded from a GitHub organization, they will be deleted, and
-
-  downloaded again.
-
-* drop only the dashboards, and load the new ones, following also this other
-
-  instructions: [How To Restore Dashboards and Charts to Defaults](faq.md#how-to-restore-dashboards-and-charts-to-defaults)
-
-## How To Restore Dashboards and Charts to Defaults
-
-In some circumstances, you may want to restore the UI dashboard and charts to its defaults. Currently, there is no clean way of doing it without deleting all the state of the UI.
-
-Following these steps, all the state modified from the UI \(charts, dashboards, saved queries, users, roles, etcetera\) will be replaced by the default ones for the version of **source{d} CE** that you're currently using. If you're using repositories from a GitHub organization, all its data will be preserved, and only charts and dashboards will be restarted.
-
-To do so, you only need to delete the docker volume containing the PostgreSQL database, and restart **source{d} CE**. It can be done following these steps if you already have [Docker Compose](https://docs.docker.com/compose/) installed:
-
-```text
-$ cd ~/.sourced/workdirs/__active__
-$ source .env
-$ docker-compose stop postgres
-$ docker-compose rm -f postgres
-$ ENV_PREFIX=`awk '{print tolower($0)}' <<< ${COMPOSE_PROJECT_NAME}`
-$ docker volume rm ${ENV_PREFIX}_postgres
-$ sourced restart
-```
 
 ## How to Update the Data from the Organizations Being Analyzed
 


### PR DESCRIPTION
`sourced restart` is slower than just waking up the new DB container, and loading the dashboards.
(especially when developing, when the user might be interested in keeping the current container)
