### PR TITLE
Increase timeout in start command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Increase timeout for start command ([#219](https://github.com/src-d/sourced-ce/pull/219))
+
 ## [v0.15.1](https://github.com/src-d/sourced-ce/releases/tag/v0.15.1) - 2019-08-27
 
 ### Fixed

--- a/cmd/sourced/cmd/start.go
+++ b/cmd/sourced/cmd/start.go
@@ -16,7 +16,7 @@ func (c *startCmd) Execute(args []string) error {
 		return err
 	}
 
-	return OpenUI(30 * time.Second)
+	return OpenUI(30 * time.Minute)
 
 }
 


### PR DESCRIPTION
The timeout was increased before for init command but start also takes
considerable time.

---

<!-- Please leave this template at the end of your description, checking the option that applies -->

* [x] I have updated the CHANGELOG file according to the conventions in [keepachangelog.com](https://keepachangelog.com)
* [ ] This PR contains changes that do not require a mention in the CHANGELOG file