### PR TITLE
Fix incompatibility of empty resourse limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix incompatibility of empty resourse limits ([#227](https://github.com/src-d/sourced-ce/issues/227))
+
 ### Removed
 
 - `completion` sub-command on Windows ([#169](https://github.com/src-d/sourced-ce/issues/169))

--- a/cmd/sourced/compose/workdir/factory.go
+++ b/cmd/sourced/compose/workdir/factory.go
@@ -166,7 +166,8 @@ func (f *envFile) MarshalEnv() ([]byte, error) {
 	}
 
 	// limit CPU for containers
-	var gitbaseLimitCPU, gitcollectorLimitCPU string
+	gitbaseLimitCPU := "0.0"
+	gitcollectorLimitCPU := "0.0"
 	dockerCPUs, err := dockerNumCPU()
 	if err != nil { // show warning
 		fmt.Println(err)
@@ -179,7 +180,7 @@ func (f *envFile) MarshalEnv() ([]byte, error) {
 	gitcollectorLimitCPU = fmt.Sprintf("%.1f", float32(dockerCPUs)/2-0.1)
 
 	// limit memory for containers
-	var gitbaseLimitMem string
+	gitbaseLimitMem := "0"
 	dockerMem, err := dockerTotalMem()
 	if err != nil { // show warning
 		fmt.Println(err)


### PR DESCRIPTION
Fix: #225

We changed syntax of defaults values in `docker-compose.yml` from
`${VAR:-default}` to `${VAR-default}`. We can't pass empty strings for
float numbers with such syntax anymore.

Signed-off-by: Maxim Sukharev <max@smacker.ru>




---

<!-- Please leave this template at the end of your description, checking the option that applies -->

* [x] I have updated the CHANGELOG file according to the conventions in [keepachangelog.com](https://keepachangelog.com)
* [ ] This PR contains changes that do not require a mention in the CHANGELOG file