### PR TITLE
Fix gitbase LOG_LEVEL var in compose file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixed
 
 - Fix incorrect value for GITCOLLECTOR_LIMIT_CPU in some cases ([#225](https://github.com/src-d/sourced-ce/issues/225))
+- Fix gitbase `LOG_LEVEL` environment variable in the compose file ([#228](https://github.com/src-d/sourced-ce/issues/228)).
 
 ## [v0.15.0](https://github.com/src-d/sourced-ce/releases/tag/v0.15.0) - 2019-08-21
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ services:
     environment:
       BBLFSH_ENDPOINT: bblfsh:9432
       SIVA: ${GITBASE_SIVA}
-      GITBASE_LOG_LEVEL: ${LOG_LEVE-info}
+      GITBASE_LOG_LEVEL: ${LOG_LEVEL-info}
     depends_on:
       - bblfsh
     volumes:


### PR DESCRIPTION
We didn't notice during the review, this was broken here: https://github.com/src-d/sourced-ce/pull/212/files#diff-4e5e90c6228fd48698d074241c2ba760R62

---

<!-- Please leave this template at the end of your description, checking the option that applies -->

* [x] I have updated the CHANGELOG file according to the conventions in [keepachangelog.com](https://keepachangelog.com)
* [ ] This PR contains changes that do not require a mention in the CHANGELOG file