### PR TITLE
Refactor #199

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Increase timeout for start command ([#219](https://github.com/src-d/sourced-ce/pull/219))
 
+### Changed
+
+- `sourced compose list` shows an index number for each compose entry, and `sourced compose set` now accepts both the name or the index number (@cmbahadir) ([#199](https://github.com/src-d/sourced-ce/issues/199)).
+
 ## [v0.15.1](https://github.com/src-d/sourced-ce/releases/tag/v0.15.1) - 2019-08-27
 
 ### Fixed

--- a/cmd/sourced/cmd/compose.go
+++ b/cmd/sourced/cmd/compose.go
@@ -74,7 +74,6 @@ type composeSetDefaultCmd struct {
 
 func (c *composeSetDefaultCmd) Execute(args []string) error {
 	files, err := composefile.List()
-
 	if err != nil {
 		return err
 	}
@@ -86,10 +85,10 @@ func (c *composeSetDefaultCmd) Execute(args []string) error {
 			active := files[index]
 			err = composefile.SetActive(active)
 		} else {
-			return fmt.Errorf("File not found with provided index check the output of 'sourced compose list'")
+			return fmt.Errorf("Index is out of range, please check the output of 'sourced compose list'")
 		}
 
-	} else if err != nil {
+	} else {
 		err := composefile.SetActive(c.Args.File)
 		if err != nil {
 			return err

--- a/test/common.go
+++ b/test/common.go
@@ -47,15 +47,17 @@ func (s *IntegrationSuite) SetupTest() {
 	s.TestDir = testDir
 	s.Commander = &Commander{bin: srcdBin, sourcedDir: filepath.Join(s.TestDir, "sourced")}
 
-	// Instead of downloading the compose file, create a link to the local file
+	// Instead of downloading the compose file, copy the local file
 	err = os.MkdirAll(filepath.Join(s.sourcedDir, "compose-files", "local"), os.ModePerm)
 	s.Require().NoError(err)
 
 	p, _ := filepath.Abs(filepath.FromSlash("../docker-compose.yml"))
-	os.Symlink(p, filepath.Join(s.sourcedDir, "compose-files", "local", "docker-compose.yml"))
+	bytes, err := ioutil.ReadFile(p)
+	s.Require().NoError(err)
+	err = ioutil.WriteFile(filepath.Join(s.sourcedDir, "compose-files", "local", "docker-compose.yml"), bytes, 0644)
+	s.Require().NoError(err)
 
-	//"0" refers to local
-	r := s.RunCommand("compose", "set", "0")
+	r := s.RunCommand("compose", "set", "local")
 	s.Require().NoError(r.Error, r.Combined())
 }
 

--- a/test/compose_test.go
+++ b/test/compose_test.go
@@ -1,0 +1,49 @@
+// +build integration
+
+package test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type ComposeTestSuite struct {
+	IntegrationSuite
+}
+
+func TestComposeTestSuite(t *testing.T) {
+	itt := ComposeTestSuite{}
+	suite.Run(t, &itt)
+}
+
+func (s *ComposeTestSuite) TestListComposeFiles() {
+	r := s.RunCommand("compose", "list")
+	s.Contains(r.Stdout(), "[0]* local")
+}
+
+func (s *ComposeTestSuite) TestSetComposeFile() {
+	r := s.RunCommand("compose", "set", "0")
+	s.Contains(r.Stdout(), "Active docker compose file was changed successfully")
+
+	r = s.RunCommand("compose", "list")
+	s.Contains(r.Stdout(), "[0]* local")
+}
+
+func (s *ComposeTestSuite) TestSetComposeFilIndexOutOfRange() {
+	r := s.RunCommand("compose", "set", "5")
+	s.Contains(r.Stderr(), "Index is out of range, please check the output of 'sourced compose list'")
+}
+
+func (s *ComposeTestSuite) TestSetComposeNotFound() {
+	r := s.RunCommand("compose", "set", "NotFound")
+	s.Error(r.Error)
+}
+
+func (s *ComposeTestSuite) TestSetComposeFilesWithStringIndex() {
+	r := s.RunCommand("compose", "set", "local")
+	s.Contains(r.Stdout(), "Active docker compose file was changed successfully")
+
+	r = s.RunCommand("compose", "list")
+	s.Contains(r.Stdout(), "[0]* local")
+}

--- a/test/init_local_test.go
+++ b/test/init_local_test.go
@@ -7,10 +7,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -41,60 +39,6 @@ func (s *InitLocalTestSuite) TestWithInvalidWorkdir() {
 		fmt.Sprintf("path '%s' is not a valid directory\n", invalidWorkDir),
 		r.Stderr(),
 	)
-}
-
-func (s *InitLocalTestSuite) TestListComposeFiles() {
-	list := "list"
-	s.T().Run(list, func(t *testing.T) {
-		assert := assert.New(t)
-
-		r := s.RunCommand("compose", list)
-		stdOut := r.Stdout()
-		check := strings.Contains(stdOut, "[0]  local")
-		assert.True(check)
-	})
-}
-
-func (s *InitLocalTestSuite) TestSetComposeFile() {
-	set := "set"
-	s.T().Run(set, func(t *testing.T) {
-		assert := assert.New(t)
-
-		r := s.RunCommand("compose", set, "0")
-		stdOut := r.Stdout()
-		check := strings.Contains(stdOut, "Active docker compose file was changed successfully")
-		assert.True(check)
-	})
-}
-
-func (s *InitLocalTestSuite) TestSetComposeFilIndexOutOfRange() {
-	set := "set"
-	s.T().Run(set, func(t *testing.T) {
-		assert := assert.New(t)
-
-		r := s.RunCommand("compose", set, "5")
-		stdErr := r.Stderr()
-		check := strings.Contains(stdErr, "File not found with provided index check the output of 'sourced compose list'")
-		assert.True(check)
-	})
-}
-
-func (s *InitLocalTestSuite) TestSetComposeNotFound() {
-	require := s.Require()
-	r := s.RunCommand("compose", "set", "NotFound")
-	require.Error(r.Error)
-}
-
-func (s *InitLocalTestSuite) TestSetComposeFilesWithStringIndex() {
-	set := "set"
-	s.T().Run(set, func(t *testing.T) {
-		assert := assert.New(t)
-
-		r := s.RunCommand("compose", set, "local")
-		stdOut := r.Stdout()
-		check := strings.Contains(stdOut, "Active docker compose file was changed successfully")
-		assert.True(check)
-	})
 }
 
 func (s *InitLocalTestSuite) TestChangeWorkdir() {


### PR DESCRIPTION
This PR adds the missing entry for #199 in the changelog.
I also changed:
- Error message when index is out of range
- Moved the integration tests for the `sourced compose` command to their own file and suite. They were mixed with the `sourced init local` tests
- Simplify the `sourced compose` tests code
- The `IntegrationSuite.SetupTest` now makes a copy of the compose file instead of a symlink. With a link, the path of `__active__` was not resolved to `local`, it was instead resolved to `sourced-ce`. So the output of `sourced compose list` was not putting the active `*` for `local`.

---

<!-- Please leave this template at the end of your description, checking the option that applies -->

* [x] I have updated the CHANGELOG file according to the conventions in [keepachangelog.com](https://keepachangelog.com)
* [ ] This PR contains changes that do not require a mention in the CHANGELOG file