### PR TITLE
Upgrade to go go-1.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ sudo: required
 language: go
 go_import_path: github.com/src-d/sourced-ce
 go:
-  - 1.12.x
+  - 1.13.x
 env:
   global:
     - GO111MODULE=on

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ go:
   - 1.13.x
 env:
   global:
-    - GO111MODULE=on
     - SOURCED_GITHUB_TOKEN=$GITHUB_TOKEN
 
 matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The changes listed under `Unreleased` section have landed in master but are not 
 
 ## [Unreleased]
 
+### Internal
+
+- Development and building of source{d} CE requires now `go 1.13` ([#242](https://github.com/src-d/sourced-ce/pull/242))
+
+
 ## [v0.16.0](https://github.com/src-d/sourced-ce/releases/tag/v0.16.0) - 2019-09-16
 
 ### Components

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/src-d/sourced-ce
 
-go 1.12
+go 1.13
 
 // See https://github.com/gotestyourself/gotest.tools/issues/156
 // replace gotest.tools => gotest.tools v2.3.0


### PR DESCRIPTION
fix #198
fix #238


According to our conventions, we should update to last go version





---

<!-- Please leave this template at the end of your description, checking the option that applies -->

* [x] I have updated the CHANGELOG file according to the conventions in [keepachangelog.com](https://keepachangelog.com)
* [ ] This PR contains changes that do not require a mention in the CHANGELOG file