### PR TITLE
Handle errors when couldn't download config or compose

### DIFF
--- a/cmd/sourced/cmd/compose.go
+++ b/cmd/sourced/cmd/compose.go
@@ -27,7 +27,7 @@ func (c *composeDownloadCmd) Execute(args []string) error {
 		v = version
 	}
 
-	err := composefile.Download(v)
+	err := composefile.ActivateFromRemote(v)
 	if err != nil {
 		return err
 	}

--- a/cmd/sourced/cmd/init.go
+++ b/cmd/sourced/cmd/init.go
@@ -126,7 +126,7 @@ func (c *initOrgsCmd) validate(orgs []string) error {
 	client := &http.Client{Transport: &authTransport{token: c.Token}}
 	r, err := client.Get("https://api.github.com/user")
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "could not validate user token")
 	}
 	if r.StatusCode == http.StatusUnauthorized {
 		return fmt.Errorf("github token is not valid")
@@ -135,7 +135,7 @@ func (c *initOrgsCmd) validate(orgs []string) error {
 	for _, org := range orgs {
 		r, err := client.Get("https://api.github.com/orgs/" + org)
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "could not validate organization")
 		}
 		if r.StatusCode == http.StatusNotFound {
 			return fmt.Errorf("organization '%s' is not found", org)

--- a/cmd/sourced/cmd/root.go
+++ b/cmd/sourced/cmd/root.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"runtime"
 
+	"github.com/src-d/sourced-ce/cmd/sourced/compose"
+	"github.com/src-d/sourced-ce/cmd/sourced/compose/file"
 	"github.com/src-d/sourced-ce/cmd/sourced/compose/workdir"
 	"github.com/src-d/sourced-ce/cmd/sourced/dir"
 	"github.com/src-d/sourced-ce/cmd/sourced/format"
@@ -65,10 +67,28 @@ func log(err error) {
 		printRed("Cannot perform this action, full re-initialization is needed, run 'prune' command first")
 	case dir.ErrNotValid.Is(err):
 		printRed("Cannot perform this action, config directory is not valid")
+	case compose.ErrComposeAlternative.Is(err):
+		printRed("docker-compose is not installed, and there was an error while trying to use the container alternative")
+		printRed("  see: https://docs.sourced.tech/community-edition/quickstart/1-install-requirements#docker-compose")
+	case file.ErrConfigDownload.Is(err):
+		printRed("The source{d} CE config file could not be set as active")
 	case fmt.Sprintf("%T", err) == "*flags.Error":
 		// syntax error is already logged by go-cli
 	default:
 		// unknown errors have no special message
+	}
+
+	switch {
+	case dir.ErrNetwork.Is(err):
+		// TODO(dpordomingo): if start using "https://golang.org/pkg/errors/",
+		//					  we could do `var myErr ErrNetwork; errors.As(err, &myErr)`
+		// 					  to provide more info about the actual network error
+		printRed("The resource could not be downloaded from the Internet")
+		printRed("  see: https://docs.sourced.tech/community-edition/quickstart/1-install-requirements#internet-connection")
+	case dir.ErrWrite.Is(err):
+		// TODO(dpordomingo): see todo above
+		printRed("could not write file")
+
 	}
 }
 

--- a/cmd/sourced/dir/dir_test.go
+++ b/cmd/sourced/dir/dir_test.go
@@ -1,6 +1,7 @@
 package dir
 
 import (
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -8,6 +9,7 @@ import (
 	"path"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -114,5 +116,10 @@ func TestDownloadURL(t *testing.T) {
 	}
 	server = httptest.NewServer(http.HandlerFunc(handler))
 	err = DownloadURL(server.URL, "/dev/null")
-	assert.EqualError(err, "HTTP status 404 Not Found")
+	errExpected := errors.Wrapf(
+		fmt.Errorf("HTTP status %v", "404 Not Found"),
+		"network error downloading %s", server.URL,
+	)
+
+	assert.EqualError(err, errExpected.Error())
 }

--- a/docs/learn-more/faq.md
+++ b/docs/learn-more/faq.md
@@ -10,6 +10,8 @@ _For tips and advices to deal with unexpected errors, please refer to [Troublesh
 - [Can I Query Gitbase or Babelfish with External Tools?](#can-i-query-gitbase-or-babelfish-with-external-tools)
 - [Where Can I Read More About the Web Interface?](#where-can-i-read-more-about-the-web-interface)
 - [I Get IOError Permission denied](#i-get-ioerror-permission-denied)
+- [Why Do I Need Internet Connection?](#why-do-i-need-internet-connection)
+
 
 ## Where Can I Find More Assistance to Run source{d} or Notify You About Any Issue or Suggestion?
 
@@ -118,6 +120,7 @@ The user interface is based in the open-sourced [Apache Superset](http://superse
 so you can also refer to [Superset tutorials](http://superset.apache.org/tutorial.html)
 for advanced usage of the web interface.
 
+
 ## I Get IOError Permission denied
 
 If you get this error message:
@@ -127,3 +130,15 @@ IOError: [Errno 13] Permission denied: u'./.env'
 ```
 
 This may happen if you have installed Docker from a snap package. This installation mode is not supported, please install it following [the official documentation](./quickstart/1-install-requirements.md#install-docker) (See [#78](https://github.com/src-d/sourced-ce/issues/78)).
+
+
+## Why Do I Need Internet Connection?
+
+source{d} CE automatically fetches some resources from the Internet when they are not found locally:
+
+- the source{d} CE configuration is fetched automatically when initializing it for the first time, using the proper version for the current version of `sourced`, e.g. if using `v0.16.0` it will automatically fetch `https://raw.githubusercontent.com/src-d/sourced-ce/v0.16.0/docker-compose.yml`.
+- to download the docker images of the source{d} CE components when initializing source{d} for the first time, or when initializing it after changing its configuration.
+- to download repositories and its metadata from GitHub when you initialize source{d} CE with `sourced init orgs`.
+- to download and install [Docker Compose alternative](#docker-compose) if there is no local installation of Docker Compose.
+
+If your connection to the network does not let source{d} CE to access to Internet, you should manually provide all these dependencies.

--- a/docs/quickstart/1-install-requirements.md
+++ b/docs/quickstart/1-install-requirements.md
@@ -15,6 +15,12 @@ Follow the instructions based on your OS:
 
 ## Docker Compose
 
-**source{d} CE** is deployed as Docker containers, using [Docker Compose](https://docs.docker.com/compose), but it is not required to have a local installation of Docker Compose; if it is not found it will be deployed inside a container.
+**source{d} CE** is deployed as Docker containers, using [Docker Compose](https://docs.docker.com/compose), but it is not required to have a local installation of Docker Compose; if it is not found it will be downloaded from docker sources, and deployed inside a container.
 
-If you prefer a local installation of Docker Compose, you can follow the [Docker Compose install guide](https://docs.docker.com/compose/install)
+If you prefer a local installation of Docker Compose, or you have no access to internet to download it, you can follow the [Docker Compose install guide](https://docs.docker.com/compose/install)
+
+## Internet Connection
+
+source{d} CE automatically fetches some resources from the Internet when they are not found locally, so in order to use all source{d} CE capacities, Internet connection is needed.
+
+For more details, you can refer to [Why Do I Need Internet Connection?](../learn-more/faq.md#why-do-i-need-internet-connection)


### PR DESCRIPTION
fix #245
motivated by https://github.com/src-d/sourced-ce/issues/241

If the user initializes or tries to download a config without access to the internet, the error is a bit cryptic.

This PR adds clearer error messages in such situations and also points to some docs explaining why is that assets needed.

---
When there is no local `docker-compose` installation, and it could not be downloaded:
- because of network error:
![image](https://user-images.githubusercontent.com/2437584/65867481-cc047100-e376-11e9-94f3-0d6b198c6531.png)

- because of write error when saving the file:
![image](https://user-images.githubusercontent.com/2437584/65867424-ac6d4880-e376-11e9-9b74-1833e10281c6.png)
---

When trying to download and activate a new `docker-compose.yml` config, but the process failed:
- because of network error:
![image](https://user-images.githubusercontent.com/2437584/65867355-89429900-e376-11e9-8093-be2afbefbaac.png)

- because of write error when saving the file:
![image](https://user-images.githubusercontent.com/2437584/65867384-93649780-e376-11e9-9958-89a3a536ec47.png)


### disclaimer

This PR does not explain how to run sourced offline, which could be done separatelly if needed.

---

<!-- Please leave this template at the end of your description, checking the option that applies -->

* [ ] I have updated the CHANGELOG file according to the conventions in [keepachangelog.com](https://keepachangelog.com)
* [x] This PR contains changes that do not require a mention in the CHANGELOG file