### PR TITLE
Run sourced-ce worker in separate container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,13 @@ The changes listed under `Unreleased` section have landed in master but are not 
 
 - `srcd/gitcollector` has been updated to [v0.0.4](https://github.com/src-d/gitcollector/releases/tag/v0.0.4).
 
+### Changed
+
+- Make celery workers to run as separate containers ([#269](https://github.com/src-d/sourced-ui/issues/269)).
+
 ### Internal
 
-- Development and building of source{d} CE requires now `go 1.13` ([#242](https://github.com/src-d/sourced-ce/pull/242))
+- Development and building of source{d} CE requires now `go 1.13` ([#242](https://github.com/src-d/sourced-ce/pull/242)).
 
 
 ## [v0.16.0](https://github.com/src-d/sourced-ce/releases/tag/v0.16.0) - 2019-09-16

--- a/cmd/sourced/compose/file/file.go
+++ b/cmd/sourced/compose/file/file.go
@@ -88,7 +88,7 @@ func InitDefaultOverride() (string, error) {
 		return "", errors.Wrap(err, "could not read the global docker-compose.override.yml file")
 	}
 
-	content := []byte(`version: '3.2'`)
+	content := []byte(`version: '3.4'`)
 	if err := ioutil.WriteFile(globalOverridePath, content, 0644); err != nil {
 		return "", errors.Wrap(err, "could not create the global docker-compose.override.yml file")
 	}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,32 @@
-version: '3.2'
+version: '3.4'
+
+x-superset-env: &superset-env
+  SYNC_MODE: ${GITBASE_SIVA}
+  ADMIN_LOGIN: admin
+  ADMIN_FIRST_NAME: admin
+  ADMIN_LAST_NAME: admin
+  ADMIN_EMAIL: admin@example.com
+  ADMIN_PASSWORD: admin
+  POSTGRES_DB: superset
+  POSTGRES_USER: superset
+  POSTGRES_PASSWORD: superset
+  POSTGRES_HOST: postgres
+  POSTGRES_PORT: 5432
+  REDIS_HOST: redis
+  REDIS_PORT: 6379
+  GITBASE_DB: gitbase
+  GITBASE_USER: root
+  GITBASE_PASSWORD:
+  GITBASE_HOST: gitbase
+  GITBASE_PORT: 3306
+  METADATA_DB: metadata
+  METADATA_USER: metadata
+  METADATA_PASSWORD: metadata
+  METADATA_HOST: metadatadb
+  METADATA_PORT: 5432
+  BBLFSH_WEB_HOST: bblfsh-web
+  BBLFSH_WEB_PORT: 8080
+
 services:
   bblfsh:
     image: bblfsh/bblfshd:v2.14.0-drivers
@@ -117,34 +145,10 @@ services:
       - metadata:/var/lib/postgresql/data
 
   sourced-ui:
-    image: srcd/sourced-ui:v0.6.0
+    image: srcd/sourced-ui:v0.7.0
     restart: unless-stopped
     environment:
-      SYNC_MODE: ${GITBASE_SIVA}
-      ADMIN_LOGIN: admin
-      ADMIN_FIRST_NAME: admin
-      ADMIN_LAST_NAME: admin
-      ADMIN_EMAIL: admin@example.com
-      ADMIN_PASSWORD: admin
-      POSTGRES_DB: superset
-      POSTGRES_USER: superset
-      POSTGRES_PASSWORD: superset
-      POSTGRES_HOST: postgres
-      POSTGRES_PORT: 5432
-      REDIS_HOST: redis
-      REDIS_PORT: 6379
-      GITBASE_DB: gitbase
-      GITBASE_USER: root
-      GITBASE_PASSWORD:
-      GITBASE_HOST: gitbase
-      GITBASE_PORT: 3306
-      METADATA_DB: metadata
-      METADATA_USER: metadata
-      METADATA_PASSWORD: metadata
-      METADATA_HOST: metadatadb
-      METADATA_PORT: 5432
-      BBLFSH_WEB_HOST: bblfsh-web
-      BBLFSH_WEB_PORT: 8080
+      <<: *superset-env
       SUPERSET_ENV: production
     ports:
       - 8088:8088
@@ -154,6 +158,19 @@ services:
       - redis
       - gitbase
       - bblfsh-web
+
+  sourced-ui-celery:
+    image: srcd/sourced-ui:v0.7.0
+    restart: unless-stopped
+    environment:
+      <<: *superset-env
+      SUPERSET_ENV: celery
+    depends_on:
+      - postgres
+      - metadatadb
+      - redis
+      - gitbase
+      - sourced-ui
 
 volumes:
   gitbase_repositories:


### PR DESCRIPTION
Ref: #269

The version of sourced-ui should be changed when new srcd-ui is released.




---

<!-- Please leave this template at the end of your description, checking the option that applies -->

* [x] I have updated the CHANGELOG file according to the conventions in [keepachangelog.com](https://keepachangelog.com)
* [ ] This PR contains changes that do not require a mention in the CHANGELOG file