### PR TITLE
Bump bblfshd to v2.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The changes listed under `Unreleased` section have landed in master but are not 
 
 ## [Unreleased]
 
+### Components
+
+- `bblfsh/bblfshd` has been updated to [v2.15.0](https://github.com/bblfsh/bblfshd/releases/tag/v2.15.0).
+
 ## [v0.17.0](https://github.com/src-d/sourced-ce/releases/tag/v0.17.0) - 2019-10-01
 
 ### Components

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ x-superset-env: &superset-env
 
 services:
   bblfsh:
-    image: bblfsh/bblfshd:v2.14.0-drivers
+    image: bblfsh/bblfshd:v2.15.0-drivers
     restart: unless-stopped
     privileged: true
     ports:


### PR DESCRIPTION
There are no interesting end-user changes so changelog just mentioned the bump.

---

<!-- Please leave this template at the end of your description, checking the option that applies -->

* [x] I have updated the CHANGELOG file according to the conventions in [keepachangelog.com](https://keepachangelog.com)
* [ ] This PR contains changes that do not require a mention in the CHANGELOG file