### PR TITLE
Bump sourced-ui to v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The changes listed under `Unreleased` section have landed in master but are not 
 ### Components
 
 - `bblfsh/bblfshd` has been updated to [v2.15.0](https://github.com/bblfsh/bblfshd/releases/tag/v2.15.0).
+- `srcd/sourced-ui` has been updated to [v0.8.1](https://github.com/src-d/sourced-ui/releases/tag/v0.8.1).
 
 ### Fixed
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -145,7 +145,7 @@ services:
       - metadata:/var/lib/postgresql/data
 
   sourced-ui:
-    image: srcd/sourced-ui:v0.7.0
+    image: srcd/sourced-ui:v0.8.1
     restart: unless-stopped
     environment:
       <<: *superset-env
@@ -160,7 +160,7 @@ services:
       - bblfsh-web
 
   sourced-ui-celery:
-    image: srcd/sourced-ui:v0.7.0
+    image: srcd/sourced-ui:v0.8.1
     restart: unless-stopped
     environment:
       <<: *superset-env


### PR DESCRIPTION
Changelog just mentions a bump as the new feature and main bug fixes aren't
related to sourced-ce.

Signed-off-by: Maxim Sukharev <max@smacker.ru>




---

<!-- Please leave this template at the end of your description, checking the option that applies -->

* [x] I have updated the CHANGELOG file according to the conventions in [keepachangelog.com](https://keepachangelog.com)
* [ ] This PR contains changes that do not require a mention in the CHANGELOG file