### PR TITLE
Bump bblfsh/web to v0.11.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,10 @@ The changes listed under `Unreleased` section have landed in master but are not 
 ### Components
 
 - `bblfsh/bblfshd` has been updated to [v2.15.0](https://github.com/bblfsh/bblfshd/releases/tag/v2.15.0).
+- `bblfsh/web` has been updated to [v0.11.4](https://github.com/bblfsh/web/releases/tag/v0.11.4).
+	- Use the same logging level as the other components reading `LOG_LEVEL` enviroment value (default: `info`) (([#263](https://github.com/src-d/sourced-ce/pull/263)).
 - `srcd/sourced-ui` has been updated to [v0.8.1](https://github.com/src-d/sourced-ui/releases/tag/v0.8.1).
+
 
 ### Fixed
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,13 +104,15 @@ services:
           memory: ${GITBASE_LIMIT_MEM-0}
 
   bblfsh-web:
-    image: bblfsh/web:v0.11.3
+    image: bblfsh/web:v0.11.4
     restart: unless-stopped
     command: -bblfsh-addr bblfsh:9432
     ports:
       - 9999:8080
     depends_on:
       - bblfsh
+    environment:
+      LOG_LEVEL: ${LOG_LEVEL-info}
 
   redis:
     image: redis:5-alpine


### PR DESCRIPTION
required by https://github.com/src-d/backlog/issues/1485
same as in https://github.com/src-d/sourced-ce/pull/159

`bblfsh/web` has been updated to [v0.11.4](https://github.com/bblfsh/web/releases/tag/v0.11.4) in order to use the same logging level as the other components reading `LOG_LEVEL` environment value (default: `info`)

---

<!-- Please leave this template at the end of your description, checking the option that applies -->

* [x] I have updated the CHANGELOG file according to the conventions in [keepachangelog.com](https://keepachangelog.com)
* [ ] This PR contains changes that do not require a mention in the CHANGELOG file